### PR TITLE
Set installation as zip_safe=False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,29 +4,30 @@
 import os
 from setuptools import setup, find_packages
 
-version_py = os.path.join(os.path.dirname(__file__), 'bcbio', 'pipeline', 'version.py')
-version = open(version_py).read().strip().split('=')[-1].replace('"','')
+version_py = os.path.join(os.path.dirname(__file__), 'bcbio', 'pipeline',
+                          'version.py')
+version = open(version_py).read().strip().split('=')[-1].replace('"', '')
 
-setup(name = "bcbio-nextgen",
-      version = version,
-      author = "Brad Chapman",
-      author_email = "chapmanb@50mail.com",
-      description = "Best-practice pipelines for fully automated high throughput sequencing analysis",
-      license = "MIT",
-      url = "https://github.com/chapmanb/bcbio-nextgen",
-      namespace_packages = ["bcbio"],
-      dependency_links = ['http://github.com/ipython/ipython/tarball/master#egg=ipython-1.0.dev'],
-      packages = find_packages(),
+setup(name="bcbio-nextgen",
+      version=version,
+      author="Brad Chapman",
+      author_email="chapmanb@50mail.com",
+      description="Best-practice pipelines for fully automated high throughput sequencing analysis",
+      license="MIT",
+      url="https://github.com/chapmanb/bcbio-nextgen",
+      namespace_packages=["bcbio"],
+      dependency_links=['http://github.com/ipython/ipython/tarball/master#egg=ipython-1.0.dev'],
+      packages=find_packages(),
       package_data={'bcbio': ['bam/data/*']},
       zip_safe=False,
-      scripts = ['scripts/bcbio_nextgen.py',
+      scripts=['scripts/bcbio_nextgen.py',
                  'scripts/bam_to_wiggle.py',
                  'scripts/barcode_sort_trim.py',
                  'scripts/illumina_finished_msg.py',
                  'scripts/nextgen_analysis_server.py',
                  'scripts/solexa_qseq_to_fastq.py',
                  ],
-      install_requires = [
+      install_requires=[
           "bioblend >= 0.2.4",
           "biopython >= 1.61",
           "boto >= 2.8.0",


### PR DESCRIPTION
This fixes issue #41 by setting zip_safe to false and ensuring the package is kept unzipped in the installation directory. This is very important for debugging.

I also fixed some PEP8 issues (spaces between "=" in functions, etc).

A current issue I've found is that at least unless the version number changes, whoever is using the zipped package will have to remove it and reinstall.
