### PR TITLE
Expanding config variables such as $GATK_PATH and $PICARD_DIR, module system specific

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -20,7 +20,7 @@ class BroadRunner:
         resources = config_utils.get_resources("gatk", config)
         self._jvm_opts = resources.get("jvm_opts", ["-Xms750m", "-Xmx2g"])
         self._picard_ref = config_utils.expand_path(picard_ref)
-        self._gatk_dir = config_utils.expand_path(patk_dir) or config_utils.expand_path(picard_ref)
+        self._gatk_dir = config_utils.expand_path(gatk_dir) or config_utils.expand_path(picard_ref)
         self._config = config
         self._resources = resources
         self._gatk_version = None


### PR DESCRIPTION
Hi Brad,

I'm setting up the upstream pipeline in our HPC cluster. Since the location of picard and GATK varies among module system installations, we have to define $GATK_HOME and $PICARD_HOME in our `bcbio_system.yaml` config file Here's a little fix for that.

Cheers!
Roman

@mariogiov, @vezzi
