### PR TITLE
Fix bed2interval from 0-base bed to 1-base interval

### DIFF
--- a/bcbio/broad/picardrun.py
+++ b/bcbio/broad/picardrun.py
@@ -279,7 +279,7 @@ def bed2interval(align_file, bed, out_file=None):
 
     def reorder_line(line):
         splitline = line.strip().split("\t")
-        reordered = "\t".join([splitline[0], splitline[1], splitline[2],
+        reordered = "\t".join([splitline[0], splitline[1]+1, splitline[2],
                                splitline[5], splitline[3]])
         return reordered + "\n"
 


### PR DESCRIPTION
From the Picard javadoc:
http://picard.sourceforge.net/javadoc/net/sf/picard/util/IntervalList.html

Interval files are 1-based whereas BED files are 0-based
