### PR TITLE
Fix bug in test_pipeline.py relating to change in programs._get_versions...

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,7 +22,7 @@ class RunInfoTest(unittest.TestCase):
         """
         config = load_config(os.path.join(self.data_dir, "automated",
                                           "post_process-sample.yaml"))
-        print programs.get_versions(config)
+        print programs._get_versions(config)
 
 class VCFUtilTest(unittest.TestCase):
     """Test various utilities for dealing with VCF files.


### PR DESCRIPTION
The function `bcbio.provenance.programs.get_versions()` was changed to `bcbio.provenance.programs._get_versions()` but a call to it in `tests/pipeline.py` also needed the update.
