### PR TITLE
Expand shell variables into paths in config_utils.py

### DIFF
--- a/bcbio/pipeline/config_utils.py
+++ b/bcbio/pipeline/config_utils.py
@@ -145,7 +145,7 @@ def _get_program_dir(name, config):
     elif isinstance(config, basestring):
         return config
     elif config.has_key("dir"):
-        return config["dir"]
+        return expand_path(config["dir"])
     else:
         raise ValueError("Could not find directory in config for %s" % name)
 


### PR DESCRIPTION
Not sure if this is an update you'd like or not but it fixes an issue I was having where the shell variable `$SNPEFF_HOME` (which we use in a config file) was not being expanded into the actual path, resulting in a file-not-found OSError for `nosetests -a speed=1`. I note that similar variables ($GATK_HOME, $PICARD_HOME) are expanded successfully so this was probably overlooked (original call from `bcbio.variation.effects._get_snpeff_genome()`)
