### PR TITLE
fixed positional argument passing bug (affected at least bowtie2 calls)

### DIFF
--- a/bcbio/pipeline/alignment.py
+++ b/bcbio/pipeline/alignment.py
@@ -96,7 +96,7 @@ def _align_from_fastq(fastq1, fastq2, aligner, align_ref, sam_ref, names,
     """
     align_fn = TOOLS[aligner].align_fn
     sam_file = align_fn(fastq1, fastq2, align_ref, names["lane"], align_dir, config,
-                        names)
+                        names=names)
     if fastq2 is None and aligner in ["bwa", "bowtie2"]:
         fastq1 = _remove_read_number(fastq1, sam_file)
     sort_method = config["algorithm"].get("bam_sort", "coordinate")


### PR DESCRIPTION
This actually undoes a change made [recently](https://github.com/chapmanb/bcbio-nextgen/commit/4029a4a33182b588270d663f7b49bbae2bf41ef0) that broke calls to `ngsalign.bowtie2.align()` -- not sure why the change was made or if this is the preferred fix, but it does seem to fix it. The issue had to do with positional argument passing landing on `extra_args` instead of `names` in the called function.
