### PR TITLE
Mutect version check

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -192,7 +192,6 @@ class BroadRunner:
         """
         if self._mutect_version is None:
             self._set_default_versions(self._config)
-            assert self._mutect_version is not None
         return self._mutect_version
 
     def gatk_type(self):


### PR DESCRIPTION
When building muTect v1.1.5 from source, the default name of the resulting jar is `muTect.jar` which causes `bcbio.provenance.programs.jar_versioner()` to report an empty version; as far as I know the only way to get v1.1.5 is to build from source (the [prebuilt binary](http://www.broadinstitute.org/cancer/cga/mutect_download) is v1.1.4). If the version for mutect is empty, this code issues a warning and continues running instead of failing on AssertionError.

I'm not sure if this is the preferred behavior but _something_ should be changed because as it stands the failure message only makes sense if the user is familiar with how the muTect version is initially determined and then knows to go change the file. Of course this will no longer be needed once Broad starts reporting the correct version.

I'm issuing a separate pull request to give an informative warning in jar_versioner if version detection fails.
