### PR TITLE
Jar versioner info

### DIFF
--- a/bcbio/provenance/programs.py
+++ b/bcbio/provenance/programs.py
@@ -9,6 +9,7 @@ import subprocess
 
 from bcbio import utils
 from bcbio.pipeline import config_utils, version
+from bcbio.log import logger
 
 import HTSeq
 
@@ -53,6 +54,9 @@ def jar_versioner(program_name, jar_name):
             jar = jar.replace(to_remove, "")
         if jar.startswith(("-", ".")):
             jar = jar[1:]
+        if jar is "":
+            logger.warn("Unable to determine version for program '{}' from jar file {}".format(program_name,
+                                                                              config_utils.get_jar(jar_name, pdir)))
         return jar
     return get_version
 


### PR DESCRIPTION
This code gives a useful error message in the event that `bcbio.provenance.programs.jar_versioner()` comes up with an empty string for a version. Another approach would be to use `distutils.version.StrictVersion()` to ensure the version has numbers and so on but that's perhaps too wide a net to cast.
