### PR TITLE
Have tophat get transcriptome index or GTF file from genome-resources yaml.

### DIFF
--- a/bcbio/ngsalign/bowtie.py
+++ b/bcbio/ngsalign/bowtie.py
@@ -24,10 +24,11 @@ def _bowtie_args_from_config(config):
     core_flags = ["-p", str(num_cores)] if num_cores > 1 else []
     return core_flags + qual_flags + multi_flags
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           extra_args=None, names=None):
     """Do standard or paired end alignment with bowtie.
     """
+    config = data['config']
     out_file = os.path.join(align_dir, "%s.sam" % out_base)
     if not file_exists(out_file):
         with file_transaction(out_file) as tx_out_file:

--- a/bcbio/ngsalign/bowtie2.py
+++ b/bcbio/ngsalign/bowtie2.py
@@ -21,10 +21,11 @@ def _bowtie2_args_from_config(config):
     core_flags = ["-p", str(num_cores)] if num_cores > 1 else []
     return core_flags + qual_flags
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           extra_args=None, names=None):
     """Alignment with bowtie2.
     """
+    config = data["config"]
     out_file = os.path.join(align_dir, "%s.sam" % out_base)
     if not file_exists(out_file):
         with file_transaction(out_file) as tx_out_file:

--- a/bcbio/ngsalign/bwa.py
+++ b/bcbio/ngsalign/bwa.py
@@ -105,10 +105,11 @@ def align_pipe(fastq_file, pair_file, ref_file, names, align_dir, data):
     data["work_bam"] = out_file
     return data
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           names=None):
     """Perform a BWA alignment, generating a SAM file.
     """
+    config = data["config"]
     sai1_file = os.path.join(align_dir, "%s_1.sai" % out_base)
     sai2_file = (os.path.join(align_dir, "%s_2.sai" % out_base)
                  if pair_file else None)

--- a/bcbio/ngsalign/mosaik.py
+++ b/bcbio/ngsalign/mosaik.py
@@ -53,10 +53,11 @@ def _get_mosaik_nn_args(out_file):
         out += [arg, arg_fname]
     return out
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           extra_args=None, names=None):
     """Alignment with MosaikAligner.
     """
+    config = data["config"]
     rg_name = names.get("rg", None) if names else None
     out_file = os.path.join(align_dir, "%s-align.bam" % out_base)
     if not file_exists(out_file):

--- a/bcbio/ngsalign/novoalign.py
+++ b/bcbio/ngsalign/novoalign.py
@@ -124,10 +124,11 @@ def _novoalign_args_from_config(config, need_quality=True):
 # -k -t 200 -K quality calibration metrics
 # paired end sizes
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           extra_args=None, names=None):
     """Align with novoalign.
     """
+    config = data["config"]
     rg_name = names.get("rg", None) if names else None
     out_file = os.path.join(align_dir, "{0}.sam".format(out_base))
     if not file_exists(out_file):

--- a/bcbio/ngsalign/star.py
+++ b/bcbio/ngsalign/star.py
@@ -14,8 +14,9 @@ ref_file = "/Users/rory/tmp/GRCm38/STAR"
 out_base = "/Users/rory/tmp/star_test/test"
 
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           names=None):
+    config = data["config"]
     out_prefix = path.join(align_dir, out_base)
     out_file = out_prefix + "Aligned.out.sam"
     if file_exists(out_file):

--- a/bcbio/ngsalign/tophat.py
+++ b/bcbio/ngsalign/tophat.py
@@ -33,33 +33,13 @@ def _set_quality_flag(options, config):
         options["solexa-quals"] = True
     return options
 
-
-def _get_transcriptome_index(ref_file):
-    base_dir = os.path.dirname(os.path.dirname(ref_file))
-    base = os.path.basename(ref_file)
-    transcriptome_index = os.path.join(base_dir, "rnaseq",
-                                      "tophat", base + "_transcriptome")
-    if file_exists(transcriptome_index + ".1.bt2"):
-        return transcriptome_index
-    else:
-        return None
-
-def _get_gtf(ref_file, config):
-    gtf_file = config.get("gtf", None)
-    if not gtf_file:
-        base_dir = os.path.dirname(os.path.dirname(ref_file))
-        gtf_file = os.path.join(base_dir, "rnaseq/ref-transcripts.gtf")
-        if not file_exists(gtf_file):
-            gtf_file = None
-    return gtf_file
-
-def _set_transcriptome_option(options, config, ref_file):
+def _set_transcriptome_option(options, data, ref_file):
     # prefer transcriptome-index vs a GTF file if available
-    transcriptome_index = _get_transcriptome_index(ref_file)
+    transcriptome_index = data["genome_resources"]["rnaseq"].get("transcriptome_index")
     if transcriptome_index:
         options["transcriptome-index"] = transcriptome_index
 
-    gtf_file = _get_gtf(ref_file, config)
+    gtf_file = data["genome_resources"]["rnaseq"].get("transcripts")
     if gtf_file:
         options["GTF"] = gtf_file
     return options
@@ -79,14 +59,15 @@ def _set_rg_options(options, names):
     options["rg-platform-unit"] = names["pu"]
     return options
 
-def tophat_align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def tophat_align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
                  names=None):
     """
     run alignment using Tophat v2
     """
+    config = data["config"]
     options = get_in(config, ("resources", "tophat", "options"), {})
     options = _set_quality_flag(options, config)
-    options = _set_transcriptome_option(options, config, ref_file)
+    options = _set_transcriptome_option(options, data, ref_file)
     options = _set_cores(options, config)
     options = _set_rg_options(options, names)
 
@@ -108,7 +89,7 @@ def tophat_align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
             if pair_file and not options.get("mate-inner-dist", None):
                 d, d_stdev = _estimate_paired_innerdist(fastq_file, pair_file,
                                                         ref_file, out_base,
-                                                        tx_out_dir, config)
+                                                        tx_out_dir, data)
                 options["mate-inner-dist"] = d
                 options["mate-std-dev"] = d_stdev
                 files.append(pair_file)
@@ -169,16 +150,16 @@ def _fix_mates(orig_file, out_file, ref_file, config):
             do.run(cmd.format(**locals()), "Fix mate pairs in TopHat output", {})
     return out_file
 
-def align(fastq_file, pair_file, ref_file, out_base, align_dir, config,
+def align(fastq_file, pair_file, ref_file, out_base, align_dir, data,
           names=None):
     out_files = tophat_align(fastq_file, pair_file, ref_file, out_base,
-                             align_dir, config, names)
+                             align_dir, data, names)
 
     return out_files
 
 
 def _estimate_paired_innerdist(fastq_file, pair_file, ref_file, out_base,
-                               out_dir, config):
+                               out_dir, data):
     """Use Bowtie to estimate the inner distance of paired reads.
     """
     # skip initial reads for large file, but not for smaller
@@ -186,10 +167,10 @@ def _estimate_paired_innerdist(fastq_file, pair_file, ref_file, out_base,
     #                              out_base, out_dir, config)
     # if it is a small file, use the old method
     mean, stdev = _small_file_innerdist("100000", fastq_file, pair_file, ref_file,
-                                        out_base, out_dir, config, True)
+                                        out_base, out_dir, data, True)
     if not mean or not stdev:
         mean, stdev = _small_file_innerdist("1", fastq_file, pair_file, ref_file,
-                                            out_base, out_dir, config, True)
+                                            out_base, out_dir, data, True)
 
     assert mean, "mean insert size is not set."
     assert stdev, "stdev of insert size is not set."
@@ -221,15 +202,15 @@ def _bowtie_for_innerdist(start, fastq_file, pair_file, ref_file, out_base,
     return mean_insert, std_deviation
 
 def _small_file_innerdist(start, fastq_file, pair_file, ref_file, out_base,
-                          out_dir, config, remove_workdir=False):
+                          out_dir, data, remove_workdir=False):
     work_dir = os.path.join(out_dir, "innerdist_estimate")
     if os.path.exists(work_dir):
         shutil.rmtree(work_dir)
     safe_makedir(work_dir)
     extra_args = ["-s", str(start), "-u", "250000"]
-    bowtie_runner = _select_bowtie_version(config)
+    bowtie_runner = _select_bowtie_version(data["config"])
     out_sam = bowtie_runner.align(fastq_file, pair_file, ref_file, out_base,
-                                  work_dir, config, extra_args)
+                                  work_dir, data, extra_args)
     dists = []
     with closing(pysam.Samfile(out_sam)) as work_sam:
         for read in work_sam:

--- a/bcbio/pipeline/alignment.py
+++ b/bcbio/pipeline/alignment.py
@@ -102,7 +102,7 @@ def _align_from_fastq(fastq1, fastq2, aligner, align_ref, sam_ref, names,
     assert not data.get("align_split"), "Do not handle split alignments with non-piped fastq yet"
     config = data["config"]
     align_fn = TOOLS[aligner].align_fn
-    sam_file = align_fn(fastq1, fastq2, align_ref, names["lane"], align_dir, config,
+    sam_file = align_fn(fastq1, fastq2, align_ref, names["lane"], align_dir, data,
                         names=names)
     if fastq2 is None and aligner in ["bwa", "bowtie2", "tophat2"]:
         fastq1 = _remove_read_number(fastq1, sam_file)
@@ -179,4 +179,3 @@ def sam_to_sort_bam(sam_file, ref_file, fastq1, fastq2, names, config):
         if fastq2:
             utils.save_diskspace(fastq2, "Merged into output BAM %s" % out_bam, config)
     return sort_bam
-


### PR DESCRIPTION
I noticed that tophat was ignoring some information in genome-resources.yaml, so I decided to fix it.

This required passing all the aligners the whole `data` dictionary, rather than just `data["config"]`. This allows them to access more information; e.g. the genome-resources. I used this to make tophat get the reference transcriptome and transcriptome index from here, rather than the hardcoded paths that it used previously. This also paves the way for other aligners to make use of this information if possible in the future.

The tests all passed, but the suite isn't comprehensive, I had to change the signature for all the aligners and I may have missed some entry points. Its probably best for someone more familiar with this code to go through my changes carefully before merging.

Also note that this a breaking change for anyone who's depending on the hardcoded paths and doesn't have their genome-resources files set up correctly.
