### PR TITLE
Add configurable species resources directory

### DIFF
--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -56,7 +56,8 @@ def _add_reference_resources(data):
     align_ref, sam_ref = genome.get_refs(data["genome_build"], aligner, data["dirs"]["galaxy"])
     data["align_ref"] = align_ref
     data["sam_ref"] = sam_ref
-    data["genome_resources"] = genome.get_resources(data["genome_build"], sam_ref)
+    ref_loc = data.get('config').get('species_resources') or sam_ref
+    data["genome_resources"] = genome.get_resources(data["genome_build"], ref_loc)
     return data
 
 # ## Sample and BAM read group naming


### PR DESCRIPTION
We don't keep our genome resources YAML files in the same place as the reference files (a shared resource), so I specify the location in our bcbio_system.yaml file.
