### PR TITLE
Compare creation times of BAM and index files

### DIFF
--- a/bcbio/broad/picardrun.py
+++ b/bcbio/broad/picardrun.py
@@ -102,7 +102,7 @@ def picard_index(picard, in_bam):
             with file_transaction(index_file) as tx_index_file:
                 opts = [("INPUT", in_bam),
                         ("OUTPUT", tx_index_file)]
-            picard.run("BuildBamIndex", opts)
+                picard.run("BuildBamIndex", opts)
 
     elif not file_exists(index_file) and not file_exists(alt_index_file):
         with file_transaction(index_file) as tx_index_file:


### PR DESCRIPTION
As a result of errors or re-runs of the pipeline, the index files may
become out of date. If this is not properly checked, this will cause
further processing by Picard to fail with odd errors
(out of bound exceptions, etc.).

The logic is not the best, so suggestions are welcome.

This fixes issue #180.
