### PR TITLE
generate_transcript_counts uses gatk . . .

### DIFF
--- a/bcbio/distributed/ipythontasks.py
+++ b/bcbio/distributed/ipythontasks.py
@@ -128,7 +128,7 @@ pipeline_summary.metadata = {"resources": ["gatk"]}
 def generate_transcript_counts(*args):
     with _setup_logging(args):
         return apply(rnaseq.generate_transcript_counts, *args)
-generate_transcript_counts.metadata = {"resources": ["samtools"]}
+generate_transcript_counts.metadata = {"resources": ["samtools","gatk"]}
 
 @require(rnaseq)
 def run_cufflinks(*args):


### PR DESCRIPTION
. . . which should be reflected in it's metadata.

This was causing me memory problems during JVM startup.
