### PR TITLE
Have picard use the work dir as tmp space during alignment.

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -17,12 +17,13 @@ from bcbio.utils import curdir_tmpdir
 class BroadRunner:
     """Simplify running Broad commandline tools.
     """
-    def __init__(self, picard_ref, gatk_dir, config):
+    def __init__(self, picard_ref, gatk_dir, config, tmp_dir=None):
         resources = config_utils.get_resources("gatk", config)
         self._jvm_opts = resources.get("jvm_opts", ["-Xms750m", "-Xmx2g"])
         self._picard_ref = config_utils.expand_path(picard_ref)
         self._gatk_dir = config_utils.expand_path(gatk_dir) or config_utils.expand_path(picard_ref)
         self._config = config
+        self.tmp_dir = tmp_dir
         self._gatk_version, self._picard_version, self._mutect_version = (
             None, None, None)
 
@@ -290,7 +291,7 @@ def _get_picard_ref(config):
         picard = config_utils.get_program("picard", config, "dir")
     return picard
 
-def runner_from_config(config, program="gatk"):
+def runner_from_config(config, program="gatk", tmp_dir=None):
     return BroadRunner(_get_picard_ref(config),
                        config_utils.get_program(program, config, "dir"),
-                       config)
+                       config, tmp_dir=tmp_dir)

--- a/bcbio/broad/picardrun.py
+++ b/bcbio/broad/picardrun.py
@@ -16,7 +16,7 @@ def picard_rnaseq_metrics(picard, align_bam, ref, ribo="null", out_file=None):
     if out_file is None:
         out_file = "%s.metrics" % (base)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", align_bam),
                         ("OUTPUT", tx_out_file),
@@ -36,7 +36,7 @@ def picard_insert_metrics(picard, align_bam, out_file=None):
         out_file = "%s-insert-metrics.txt" % (base)
     histogram = "%s-insert-histogram.pdf" % (base)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", align_bam),
                         ("OUTPUT", tx_out_file),
@@ -54,7 +54,7 @@ def picard_sort(picard, align_bam, sort_order="coordinate",
     if out_file is None:
         out_file = "%s-sort%s" % (base, ext)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", align_bam),
                         ("OUTPUT", out_file if pipe else tx_out_file),
@@ -72,7 +72,7 @@ def picard_merge(picard, in_files, out_file=None,
     if out_file is None:
         out_file = "%smerge.bam" % os.path.commonprefix(in_files)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("OUTPUT", tx_out_file),
                         ("SORT_ORDER", "coordinate"),
@@ -99,7 +99,7 @@ def picard_reorder(picard, in_bam, ref_file, out_file):
     """Reorder BAM file to match reference file ordering.
     """
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", in_bam),
                         ("OUTPUT", tx_out_file),
@@ -114,7 +114,7 @@ def picard_fix_rgs(picard, in_bam, names):
     """
     out_file = "%s-fixrgs.bam" % os.path.splitext(in_bam)[0]
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", in_bam),
                         ("OUTPUT", tx_out_file),
@@ -131,7 +131,7 @@ def picard_fix_rgs(picard, in_bam, names):
 def picard_downsample(picard, in_bam, ds_pct, random_seed=None):
     out_file = "%s-downsample%s" % os.path.splitext(in_bam)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", in_bam),
                         ("OUTPUT", tx_out_file),
@@ -159,7 +159,7 @@ def picard_fastq_to_bam(picard, fastq_one, fastq_two, out_dir, names, order="que
     out_bam = os.path.join(out_dir, "%s-fastq.bam" %
                            os.path.splitext(os.path.basename(fastq_one))[0])
     if not file_exists(out_bam):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_bam) as tx_out_bam:
                 opts = [("FASTQ", fastq_one),
                         ("READ_GROUP_NAME", names["rg"]),
@@ -178,7 +178,7 @@ def picard_bam_to_fastq(picard, in_bam, fastq_one, fastq_two=None):
     """Convert BAM file to fastq.
     """
     if not file_exists(fastq_one):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(fastq_one) as tx_out1:
                 opts = [("INPUT", in_bam),
                         ("FASTQ", tx_out1),
@@ -200,7 +200,7 @@ def picard_sam_to_bam(picard, align_sam, fastq_bam, ref_file,
     else:
         raise NotImplementedError("Input format not recognized")
     if not file_exists(out_bam):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_bam) as tx_out_bam:
                 opts = [("UNMAPPED", fastq_bam),
                         ("ALIGNED", align_sam),
@@ -218,7 +218,7 @@ def picard_formatconverter(picard, align_sam):
     """
     out_bam = "%s.bam" % os.path.splitext(align_sam)[0]
     if not file_exists(out_bam):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_bam) as tx_out_bam:
                 opts = [("INPUT", align_sam),
                         ("OUTPUT", tx_out_bam),
@@ -232,7 +232,7 @@ def picard_mark_duplicates(picard, align_bam, remove_dups=False):
     dup_bam = "%s-dup%s" % (base, ext)
     dup_metrics = "%s-dup.dup_metrics" % base
     if not file_exists(dup_bam):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(dup_bam, dup_metrics) as (tx_dup_bam, tx_dup_metrics):
                 opts = [("INPUT", align_bam),
                         ("OUTPUT", tx_dup_bam),
@@ -250,7 +250,7 @@ def picard_fixmate(picard, align_bam):
     base, ext = os.path.splitext(align_bam)
     out_file = "%s-sort%s" % (base, ext)
     if not file_exists(out_file):
-        with curdir_tmpdir() as tmp_dir:
+        with curdir_tmpdir(base_dir=picard.tmp_dir) as tmp_dir:
             with file_transaction(out_file) as tx_out_file:
                 opts = [("INPUT", align_bam),
                         ("OUTPUT", tx_out_file),

--- a/bcbio/pipeline/alignment.py
+++ b/bcbio/pipeline/alignment.py
@@ -111,9 +111,9 @@ def _align_from_fastq(fastq1, fastq2, aligner, align_ref, sam_ref, names,
     sort_method = config["algorithm"].get("bam_sort", "coordinate")
 
     if sort_method == "queryname":
-        return sam_to_querysort_bam(sam_file, config)
+        return sam_to_querysort_bam(sam_file, data)
     else:
-        return sam_to_sort_bam(sam_file, sam_ref, fastq1, fastq2, names, config)
+        return sam_to_sort_bam(sam_file, sam_ref, fastq1, fastq2, names, data)
 
 def _remove_read_number(in_file, sam_file):
     """Work around problem with MergeBamAlignment with BWA and single end reads.
@@ -144,28 +144,23 @@ def _remove_read_number(in_file, sam_file):
                             out_handle.write("@%s\n%s\n+\n%s\n" % (name, seq, qual))
     return out_file
 
-def sam_to_querysort_bam(sam_file, config):
+def sam_to_querysort_bam(sam_file, data):
     """Convert SAM file directly to a query sorted BAM without merging of FASTQ reads.
 
     This allows merging of multiple mappers which do not work with MergeBamAlignment.
     """
-    runner = broad.runner_from_config(config)
+    config = data["config"]
+    tmp_dir = os.path.join(data["dirs"]["work"], "tmp")
+    runner = broad.runner_from_config(config, tmp_dir=tmp_dir)
     out_file = "{}-querysorted.bam".format(os.path.splitext(sam_file)[0])
     return runner.run_fn("picard_sort", sam_file, "queryname", out_file)
 
-def sam_to_querysort_sam(sam_file, config):
-    """Convert SAM file directly to a query sorted SAM without merging of FASTQ reads.
-
-    This allows merging of multiple mappers which do not work with MergeBamAlignment.
-    """
-    runner = broad.runner_from_config(config)
-    out_file = "{}-querysorted.sam".format(os.path.splitext(sam_file)[0])
-    return runner.run_fn("picard_sort", sam_file, "queryname", out_file)
-
-def sam_to_sort_bam(sam_file, ref_file, fastq1, fastq2, names, config):
+def sam_to_sort_bam(sam_file, ref_file, fastq1, fastq2, names, data):
     """Convert SAM file to merged and sorted BAM file.
     """
-    picard = broad.runner_from_config(config)
+    config = data["config"]
+    tmp_dir = os.path.join(data["dirs"]["work"], "tmp")
+    picard = broad.runner_from_config(config, tmp_dir=tmp_dir)
     base_dir = os.path.dirname(sam_file)
 
     picard.run_fn("picard_index_ref", ref_file)
@@ -185,4 +180,3 @@ def sam_to_sort_bam(sam_file, ref_file, fastq1, fastq2, names, config):
         if fastq2:
             utils.save_diskspace(fastq2, "Merged into output BAM %s" % out_bam, config)
     return sort_bam
-


### PR DESCRIPTION
Prior to this; picard would create tmp directories on my compute nodes, which are tiny (in terms of diskspace). Picard also generates gigabytes of tmp data while working, so the disk could sometimes fill up, resulting in the whole system crashing to a halt. This patch introduces an optional `tmp_dir` parameter to the `BroadRunner` constructor, which can is then used later to make sure picard puts tmp directories there, as opposed to wherever it happens to be running. The tmp dir is then set to `os.path.join(dirs["work"],"tmp")` so that tmp files get created on my NFS (where space is effectively infinite).

If we're going to be consistent about this there are probably myriad other places where `runner_from_config` should be passed a `tmp_dir`, but this solves my immediate problem and I didn't want to make too sweeping of a change without some discussion.
