### PR TITLE
Fix grammatical error that bothers me every time I see it

### DIFF
--- a/bcbio/provenance/system.py
+++ b/bcbio/provenance/system.py
@@ -35,7 +35,7 @@ def write_info(dirs, run_parallel, parallel, config):
                 yaml.dump(minfos, out_handle, default_flow_style=False, allow_unicode=False)
 
 def _get_machine_info(parallel, run_parallel, sys_config):
-    """Get machine resource information from the job scheduler via either the command-line or the queue.
+    """Get machine resource information from the job scheduler via either the command line or the queue.
     """
     if parallel.get("queue") and parallel.get("scheduler"):
         # dictionary as switch statement; can add new scheduler implementation functions as (lowercase) keys


### PR DESCRIPTION
I know this seems minor but it cannot remain as it is. Another possible fix is to append the word "interface" so that "command-line" is a compound modifier, which would actually require hyphenation.
