### PR TITLE
add min_read_length to ALGORITHM_KEYS

### DIFF
--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -138,7 +138,7 @@ ALGORITHM_KEYS = set(["platform", "aligner", "bam_clean", "bam_sort",
                       "validate_regions", "validate_genome_build",
                       "clinical_reporting", "nomap_split_size",
                       "nomap_split_targets", "ensemble",
-                      "disambiguate", "strandedness", "fusion_mode"])
+                      "disambiguate", "strandedness", "fusion_mode", "min_read_length"])
 
 def _check_algorithm_keys(item):
     """Check for unexpected keys in the algorithm section.


### PR DESCRIPTION
[This line](https://github.com/chapmanb/bcbio-nextgen/blob/master/bcbio/bam/trim.py#L36) would seem to imply this is a valid parameter; but the pipeline throws an error if you try to use it.
