### PR TITLE
Ensure that gunzipping gets done in parallel.

### DIFF
--- a/bcbio/pipeline/fastq.py
+++ b/bcbio/pipeline/fastq.py
@@ -16,7 +16,7 @@ def needs_fastq_conversion(item, config):
     if item.get("test_run", False):
         return True
     for f in item.get("files", []):
-        if f.endswith(".bam") and _pipeline_needs_fastq(config, item):
+        if (f.endswith(".bam") or f.endswith(".gz")) and _pipeline_needs_fastq(config, item):
             return True
     return False
 


### PR DESCRIPTION
There's also a [check for this](https://github.com/chapmanb/bcbio-nextgen/blob/master/bcbio/pipeline/fastq.py#L42) in `get_fastq_files`, which might be redundant now.
