### PR TITLE
Added support for tumor-only calling and use of normal_panel vcf in mute...

### DIFF
--- a/bcbio/variation/mutect.py
+++ b/bcbio/variation/mutect.py
@@ -71,14 +71,14 @@ def _mutect_call_prep(align_bams, items, ref_file, assoc_files,
     params = ["-R", ref_file, "-T", "MuTect"]
 
     paired = vcfutils.get_paired_bams(align_bams, items)
-    print paired
-    if not paired.normal_bam:
-        raise ValueError("Require both tumor and normal BAM files for MuTect cancer calling")
     params += ["-I:tumor", paired.tumor_bam]
     params += ["--tumor_sample_name", paired.tumor_name]
-    params += ["-I:normal", paired.normal_bam]
-    params += ["--normal_sample_name", paired.normal_name]
-
+    if paired.normal_bam is not None:
+        params += ["-I:normal", paired.normal_bam]
+        params += ["--normal_sample_name", paired.normal_name]
+    if paired.normal_panel is not None:
+        params += ["--normal_panel", paired.normal_panel]
+    
     params += _config_params(base_config, assoc_files, region, out_file)
     return broad_runner, params
 

--- a/tests/data/automated/run_info-cancer2.yaml
+++ b/tests/data/automated/run_info-cancer2.yaml
@@ -1,4 +1,4 @@
-# Test cancer runs without normal matches samples or using pre-called
+# Test cancer runs without normal matched samples or using pre-called
 # normal panels input as VCF files
 ---
 upload:
@@ -10,7 +10,7 @@ fc_name: tcancer2
 globals:
   normal_panel1: ../data/reference_material/7_100326_FC6107FAAXX-grade.vcf
 details:
-  - analysis: variant
+  - analysis: variant2
     description: c-tumor
     files: [../data/tcga_benchmark/HCC1143-tumor.bam]
     genome_build: hg19
@@ -23,4 +23,4 @@ details:
       recalibrate: false
       realign: false
       variantcaller: mutect
-      background: normal_panel1
+      background: ../data/reference_material/7_100326_FC6107FAAXX-grade.vcf #normal_panel1


### PR DESCRIPTION
...ct.py

Hi Brad,
If you look at this pull request, it will run the cancer_devel test past mutect calling just fine, but then dies at a later stage because of missing 'normal' in the vcf I reckon. Error thread below:

```
[2014-02-06 11:41] multiprocessing: split_variants_by_sample
Traceback (most recent call last):
  File "/home/klrl262/miniconda/envs/bcbio-test/bin/bcbio_nextgen.py", line 5, in <module>
    pkg_resources.run_script('bcbio-nextgen==0.7.7a', 'bcbio_nextgen.py')
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/pkg_resources.py", line 505, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/pkg_resources.py", line 1245, in run_script
    execfile(script_filename, namespace, namespace)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/EGG-INFO/scripts/bcbio_nextgen.py", line 59, in <module>
    main(**kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/EGG-INFO/scripts/bcbio_nextgen.py", line 39, in main
    run_main(**kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/pipeline/main.py", line 41, in run_main
    fc_dir, run_info_yaml)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/pipeline/main.py", line 88, in _run_toplevel
    for xs in pipeline.run(config, config_file, parallel, dirs, pipeline_items):
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/pipeline/main.py", line 311, in run
    samples = region.parallel_variantcall_region(samples, run_parallel)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/pipeline/region.py", line 133, in parallel_variantcall_region
    "vrn_file", ["region", "sam_ref", "config"])
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/distributed/split.py", line 36, in grouped_parallel_split_combine
    ungrouped_output = parallel_fn(ungroup_name, grouped_output)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/distributed/multi.py", line 27, in run_parallel
    return run_multicore(fn, items, config, parallel=parallel)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/distributed/multi.py", line 81, in run_multicore
    for data in joblib.Parallel(parallel["num_jobs"])(joblib.delayed(fn)(x) for x in items):
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/joblib-0.8.0a3-py2.7.egg/joblib/parallel.py", line 644, in __call__
    self.dispatch(function, args, kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/joblib-0.8.0a3-py2.7.egg/joblib/parallel.py", line 391, in dispatch
    job = ImmediateApply(func, args, kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/joblib-0.8.0a3-py2.7.egg/joblib/parallel.py", line 129, in __init__
    self.results = func(*args, **kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/utils.py", line 46, in wrapper
    return apply(f, *args, **kwargs)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/distributed/multitasks.py", line 57, in split_variants_by_sample
    return multi.split_variants_by_sample(*args)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/site-packages/bcbio_nextgen-0.7.7a-py2.7.egg/bcbio/variation/multi.py", line 60, in split_variants_by_sample
    assert vcfutils.get_paired_phenotype(data["group_orig"][0][0]) == "normal"
AssertionError
ERROR

======================================================================
ERROR: Test cancer calling without normal samples or with normal VCF panels.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/klrl262/dev/bcbio-nextgen/tests/test_automated_analysis.py", line 283, in test_7_cancer_nonormal
    subprocess.check_call(cl)
  File "/home/klrl262/miniconda/envs/bcbio-test/lib/python2.7/subprocess.py", line 542, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['bcbio_nextgen.py', '/home/klrl262/dev/bcbio-nextgen/tests/data/automated/post_process-sample.yaml', '/home/klrl262/dev/bcbio-nextgen/tests/data/automated/run_info-cancer2.yaml']' returned non-zero exit status 1

----------------------------------------------------------------------
Ran 1 test in 29.398s
```
