### PR TITLE
Add --strand-filter 1 to VarScan somatic options

### DIFF
--- a/bcbio/variation/varscan.py
+++ b/bcbio/variation/varscan.py
@@ -98,7 +98,8 @@ def _varscan_paired(align_bams, ref_file, items, target_regions, out_file):
         jvm_opts = _get_varscan_opts(config)
         varscan_cmd = ("java {jvm_opts} -jar {varscan_jar} somatic"
                        " {normal_tmp_mpileup} {tumor_tmp_mpileup} {base}"
-                       " --output-vcf --min-coverage 5 --p-value 0.98")
+                       " --output-vcf --min-coverage 5 --p-value 0.98 "
+                       "--strand-filter 1 ")
 
         indel_file = base + ".indel.vcf"
         snp_file = base + ".snp.vcf"


### PR DESCRIPTION
This is done in order to filter variants with extremely high (>90%) strand bias. I've noticed these in my outputs and I'd rather keep them out of the way (as they could be errors).

From VarScan help:

```
--strand-filter - If set to 1, removes variants with >90% strand bias [0]
```
