### PR TITLE
Mac OS X: use a lower value of target_procs

### DIFF
--- a/bcbio/pipeline/main.py
+++ b/bcbio/pipeline/main.py
@@ -52,7 +52,7 @@ def _setup_resources():
     This allows us to avoid out of file handle limits where we can
     move beyond the soft limit up to the hard limit.
     """
-    target_procs = 50000
+    target_procs = 10240
     cur_proc, max_proc = resource.getrlimit(resource.RLIMIT_NPROC)
     target_proc = min(max_proc, target_procs)
     resource.setrlimit(resource.RLIMIT_NPROC, (max(cur_proc, target_proc), max_proc))


### PR DESCRIPTION
By default on Mac OS X the maximum number of files a process can open is 10,240. Unless the number 50,000 was chosen for a good reason, I suggest we change `target_procs` to `10240` to ensure a better out-of-the-box experience for Mac users.

The alternative would be to add a check for OS X before lowering `target_procs`.
