### PR TITLE
Added configurable min-alternate-fraction to FreeBayes

### DIFF
--- a/bcbio/variation/freebayes.py
+++ b/bcbio/variation/freebayes.py
@@ -35,6 +35,11 @@ def _freebayes_options_from_config(items, config, out_file, region=None):
     resources = config_utils.get_resources("freebayes", config)
     if resources.get("options"):
         opts += resources["options"]
+    if "--min-alternate-fraction" not in " ".join(opts) and "-F" not in " ".join(opts):
+        # add minimum reportable allele frequency, for which FreeBayes defaults to 20
+         min_af = float(utils.get_in(config, ("algorithm", 
+                                              "min_allele_fraction"),20)) / 100.0
+         opts += ["--min-alternate-fraction", str(min_af)]
     return opts
 
 def run_freebayes(align_bams, items, ref_file, assoc_files, region=None,
@@ -101,6 +106,11 @@ def _run_freebayes_paired(align_bams, items, ref_file, assoc_files,
             freebayes = config_utils.get_program("freebayes", config)
             opts = " ".join(_freebayes_options_from_config(items, config, out_file, region))
             opts += " -f {}".format(ref_file)
+            if "--min-alternate-fraction" not in opts and "-F" not in opts:
+                # add minimum reportable allele frequency, for which FreeBayes defaults to 20
+                min_af = float(utils.get_in(paired.tumor_config, ("algorithm", 
+                                                                  "min_allele_fraction"),20)) / 100.0
+                opts += " --min-alternate-fraction %s" % min_af
             # NOTE: The first sample name in the vcfsamplediff call is
             # the one supposed to be the *germline* one
 


### PR DESCRIPTION
Hi Guys,
I added the configurable minimum AF option into FreeBayes based on Brad's backend work. Defaults to 20 (FreeBayes default) in both single and paired end calling, happy to change these.

In addition, I think it would be nice if FreeBayes didn't die in case singleton tumor samples were given to it. I think it could just revert to single sample mode or something.. opinions anyone? This would be practical in case of combining variant calling across methods, where MuTect supports single sample tumors (but not single sample normals).
