### PR TITLE
Cn.mops support bed files

### DIFF
--- a/bcbio/structural/cn_mops.py
+++ b/bcbio/structural/cn_mops.py
@@ -113,7 +113,8 @@ def _population_load_script(work_bams, names, chrom, pairmode, items):
     """Prepare BAMs for assessing CNVs in a population.
     """
     bed_file = items[0]["config"]["algorithm"].get("variant_regions", None)
-    if utils.file_exists(bed_file):
+    is_genome = items[0]["config"]["algorithm"].get("coverage_interval", "exome").lower() in ["genome"]
+    if utils.file_exists(bed_file) and not is_genome:
         return _population_prep_targeted.format(bam_file_str=",".join(work_bams), names_str=",".join(names),
                                                 chrom=chrom, num_cores=0, pairmode=pairmode, bed_file=bed_file)
     else:
@@ -125,7 +126,8 @@ def _paired_load_script(work_bams, names, chrom, pairmode, items):
     """
     paired = vcfutils.get_paired_bams(work_bams, items)
     bed_file = items[0]["config"]["algorithm"].get("variant_regions", None)
-    if utils.file_exists(bed_file):
+    is_genome = items[0]["config"]["algorithm"].get("coverage_interval", "exome").lower() in ["genome"]
+    if utils.file_exists(bed_file) and not is_genome:
         return _paired_prep_targeted.format(case_file=paired.tumor_bam, case_name=paired.tumor_name,
                                             ctrl_file=paired.normal_bam, ctrl_name=paired.normal_name,
                                             num_cores=0, chrom=chrom, pairmode=pairmode, bed_file=bed_file)


### PR DESCRIPTION
Hi Brad,
I added the discussed (https://github.com/chapmanb/bcbio-nextgen/issues/395) regional support into cn.mops, but I just realised that items[0]["config"]["algorithm"].get("variant_regions", None) probably exists for all analyses, including whole genome (as it points to the callable regions bed file)? Do you know if another bed file would be more appropriate?
