### PR TITLE
SGE: Moved from minimum mem/core ratio to median

### DIFF
--- a/bcbio/provenance/system.py
+++ b/bcbio/provenance/system.py
@@ -10,7 +10,6 @@ import resource
 import shlex
 import socket
 import subprocess
-import numpy
 
 import yaml
 from xml.etree import ElementTree as ET
@@ -112,6 +111,13 @@ def _torque_queue_nodes(queue):
                 hosts.extend(line.strip().split(","))
     return tuple([h.split(".")[0].strip() for h in hosts if h.strip()])
 
+def median_left(x):
+    if len(x) < 1:
+        return None
+    sortedval = sorted(x)
+    centre = int((len(sortedval)-1)/2)
+    return sortedval[centre]
+
 def _sge_info(queue):
     """Returns machine information for an sge job scheduler.
     """
@@ -124,7 +130,7 @@ def _sge_info(queue):
     #num_cpus_vec = [slot_info[x]["slots_total"] for x in machine_keys]
     #mem_vec = [mem_info[x]["mem_total"] for x in machine_keys]
     mem_per_slot = [mem_info[x]["mem_total"] / float(slot_info[x]["slots_total"]) for x in machine_keys]
-    min_ratio_index = mem_per_slot.index(numpy.median(mem_per_slot))
+    min_ratio_index = mem_per_slot.index(median_left(mem_per_slot))
     mem_info[machine_keys[min_ratio_index]]["mem_total"]
     return [{"cores": slot_info[machine_keys[min_ratio_index]]["slots_total"],
              "memory": mem_info[machine_keys[min_ratio_index]]["mem_total"],


### PR DESCRIPTION
Hi Brad / Rory,
We've noticed that the lowest common denominator approach is too conservative in our heterogeneous cluster. If you're happy, we'd be happy with using median instead, plus using other SGE tricks to control over allocation of memory (the `mem_free` consumable resource approach).
