### PR TITLE
kraken into QC-summary for rnaseq pipeline

### DIFF
--- a/bcbio/bam/__init__.py
+++ b/bcbio/bam/__init__.py
@@ -61,6 +61,13 @@ def get_downsample_pct(runner, in_bam, target_counts):
     if total > rg_target:
         return float(rg_target) / float(total)
 
+def get_aligned_reads(in_bam,data):
+    broad_runner = broad.runner_from_config(data["config"])
+    index(in_bam, data["config"])
+    align = sum(x.aligned for x in broad_runner.run_fn("picard_idxstats", in_bam))
+    total = count(in_bam,data["config"])
+    return 1.0 * align / total
+
 def downsample(in_bam, data, target_counts):
     """Downsample a BAM file to the specified number of target counts.
     """

--- a/bcbio/pipeline/main.py
+++ b/bcbio/pipeline/main.py
@@ -310,10 +310,11 @@ class RnaseqPipeline(AbstractPipeline):
             with profile.report("estimate expression", dirs):
                 samples = rnaseq.estimate_expression(samples, run_parallel)
 
-        with prun.start(_wres(parallel, ["picard", "fastqc", "rnaseqc"]),
+        with prun.start(_wres(parallel, ["picard", "fastqc", "rnaseqc","kraken"]),
                         samples, config, dirs, "persample") as run_parallel:
             with profile.report("quality control", dirs):
                 samples = qcsummary.generate_parallel(samples, run_parallel)
+        
         logger.info("Timing: finished")
         return samples
 

--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -22,6 +22,7 @@ from bcbio import bam, utils
 from bcbio.distributed.transaction import file_transaction
 from bcbio.log import logger
 from bcbio.pipeline import config_utils, run_info
+from bcbio.install import _get_data_dir
 from bcbio.provenance import do
 import bcbio.rnaseq.qc
 from bcbio.variation.realign import has_aligned_reads
@@ -47,7 +48,7 @@ def pipeline_summary(data):
     """Provide summary information on processing sample.
     """
     work_bam = data.get("work_bam")
-    if data["sam_ref"] is not None and work_bam and work_bam.endswith(".bam") and has_aligned_reads(work_bam):
+    if data["sam_ref"] is not None and work_bam and work_bam.endswith(".bam"):
         logger.info("Generating summary files: %s" % str(data["name"]))
         data["summary"] = _run_qc_tools(work_bam, data)
     return [[data]]
@@ -79,6 +80,7 @@ def prep_pdf(qc_dir, config):
 def _run_qc_tools(bam_file, data):
     """Run a set of third party quality control tools, returning QC directory and metrics.
     """
+    metrics = {}
     to_run = [("fastqc", _run_fastqc)]
     if data["analysis"].lower().startswith("rna-seq"):
         to_run.append(("rnaseqc", bcbio.rnaseq.qc.sample_summary))
@@ -93,6 +95,10 @@ def _run_qc_tools(bam_file, data):
     for program_name, qc_fn in to_run:
         cur_qc_dir = os.path.join(qc_dir, program_name)
         cur_metrics = qc_fn(bam_file, data, cur_qc_dir)
+        metrics.update(cur_metrics)
+    ratio = bam.get_aligned_reads(bam_file,data)
+    if ratio < 0.60 and data['config']["algorithm"].get("kraken", False) and data["analysis"].lower() == "rna-seq":
+        cur_metrics =_run_kraken(data, ratio)
         metrics.update(cur_metrics)
     metrics["Name"] = data["name"][-1]
     metrics["Quality format"] = utils.get_in(data,
@@ -128,6 +134,7 @@ def write_project_summary(samples):
         yaml.safe_dump({"samples": prev_samples + [_save_fields(sample[0]) for sample in samples]}, out_handle,
                        default_flow_style=False, allow_unicode=False)
     return out_file
+
 
 def _other_pipeline_samples(summary_file, cur_samples):
     """Retrieve samples produced previously by another pipeline in the summary output.
@@ -251,6 +258,64 @@ def _run_gene_coverage(bam_file, data, out_dir):
         plot_gene_coverage(bam_file, ref_file, count_file, tx_out_file)
     return {"gene_coverage": out_file}
 
+
+
+def _run_kraken(data,ratio):
+    """Run kraken, generating report in specified directory and parsing metrics.
+       Using only first paired reads.
+    """
+    logger.info("Number of aligned reads < than 0.60 in %s: %s" % (str(data["name"]),ratio))
+    logger.info("Running kraken to determine contaminant: %s" % str(data["name"]))
+    qc_dir = utils.safe_makedir(os.path.join(data["dirs"]["work"], "qc", data["description"]))
+    kraken_out = os.path.join(qc_dir, "kraken")
+    stats = out = out_stats = None
+    db = data['config']["algorithm"]["kraken"] 
+    if db == "minikraken":
+        db = os.path.join(_get_data_dir(),"genome","kraken","minikraken")
+    else:
+        if not os.path.exists(db):
+            logger.info("kraken: no database found %s, skipping" % db)
+            return {"kraken_report" : "null"}
+    if not os.path.exists(os.path.join(kraken_out,"kraken_out")):
+        work_dir = os.path.dirname(kraken_out)
+        utils.safe_makedir(work_dir)
+        num_cores = data["config"]["algorithm"].get("num_cores", 1)
+        files = data["files"]        
+        with utils.curdir_tmpdir(data, work_dir) as tx_tmp_dir:
+            with utils.chdir(tx_tmp_dir):
+                out = os.path.join(tx_tmp_dir,"kraken_out")
+                out_stats = os.path.join(tx_tmp_dir,"kraken_stats")
+                cl = (" ").join([config_utils.get_program("kraken", data["config"]),
+                      "--db",db,"--quick",
+                      "--preload","--min-hits","2","--threads",str(num_cores), 
+                      "--out", out, files[0]," 2>",out_stats])
+                do.run(cl,"kraken: %s" % data["name"][-1])
+                if os.path.exists(kraken_out):
+                    shutil.rmtree(kraken_out)
+                shutil.move(tx_tmp_dir, kraken_out)
+    metrics = _parse_kraken_output(kraken_out,db,data)
+    return metrics
+
+def _parse_kraken_output(out_dir, db, data):
+    """Parse kraken stat info comming from stderr, 
+       generating report with kraken-report
+    """
+    in_file = os.path.join(out_dir,"kraken_out")
+    stat_file = os.path.join(out_dir,"kraken_stats")
+    out_file = os.path.join(out_dir, "kraken_summary")
+    classify = unclassify = None
+    with open(stat_file,'r') as handle:
+        for line in handle:
+            if line.find(" classified") > -1:
+                classify = line[line.find("(")+1:line.find(")")]
+            if line.find(" unclassified") > -1:
+                unclassify = line[line.find("(")+1:line.find(")")]
+    if os.path.getsize(in_file)>0:
+        with file_transaction(out_file) as tx_out_file:
+            cl = (" ").join([config_utils.get_program("kraken-report", data["config"]),
+                          "--db",db,in_file,">",tx_out_file])
+            do.run(cl, "kraken report: %s" % data["name"][-1])
+    return {"kraken_report" : out_file,"kraken_clas": classify,"kraken_unclas": unclassify}
 
 def _run_fastqc(bam_file, data, fastqc_out):
     """Run fastqc, generating report in specified directory and parsing metrics.

--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -151,7 +151,7 @@ def _check_for_misplaced(xs, subkey, other_keys):
                                    ["% 15s | % 15s | % 15s" % (a, b, c) for (a, b, c) in problems]))
 
 ALGORITHM_KEYS = set(["platform", "aligner", "bam_clean", "bam_sort",
-                      "trim_reads", "adapters", "custom_trim",
+                      "trim_reads", "adapters", "custom_trim","kraken",
                       "align_split_size", "quality_bin",
                       "quality_format", "write_summary",
                       "merge_bamprep", "coverage",

--- a/config/bcbio_system.yaml
+++ b/config/bcbio_system.yaml
@@ -37,6 +37,9 @@ resources:
     memory: 4G
   gemini:
     cores: 16
+  kraken:
+    cores: 6
+    memory: 4g
   freebayes:
     memory: 2g
   gatk:


### PR DESCRIPTION
quite a big pull request, so please take a look if it makes sense. 

I just added to RNAseq pipeline, for now. Easy to add to the others, but maybe better to start with this. Add some metrics to the project-summary as well. % of detected reads in the kraken database, and link to the summary file.

I try to change the minimum as possible and reuse code. Some re-arrangement in QC-summary, so Rory, if you can look at it carefully, better. 

let me know if I miss something.

test for rnaseq is working, and when I run my particular test with `kraken : true` is working as well.

Right now need to set up `kraken_db` to use the database that the user has to have somewhere, but planning to add the database to be installed with bcbio soon. 

don't know if you want to wait until I change that as well, I thought that that was too many changes.

Probably I will do a pull request to cloudBioLinux to add kraken to be installed with the other tools as well.
