### PR TITLE
Add a dummy readgroup to bowtie2 alignments.

### DIFF
--- a/bcbio/ngsalign/bowtie2.py
+++ b/bcbio/ngsalign/bowtie2.py
@@ -48,7 +48,7 @@ def align(fastq_file, pair_file, ref_file, names, align_dir, data,
             else:
                 cl += ["-U", fastq_file]
             cl += ["-S", tx_out_file]
-            if not names and names.has_key("rg"):
+            if names and names.has_key("rg"):
                 cl += ["--rg-id", names["rg"]]
                 for key, tag in [("sample", "SM"), ("pl", "PL"), ("pu", "PU")]:
                     if names.has_key(key):


### PR DESCRIPTION
We encountered a minor problem where bams created with bowtie2 fail in downstream processing because they lack read groups.  This patch creates a dummy read group ID with a bowtie2 command flag and lets the bowtie2 chip-seq pipeline complete without errors.
