### PR TITLE
use the name than in the yaml file for the final files of qsignature

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -733,7 +733,7 @@ def _parse_qsignature_output(in_file, out_file, warning_file, data):
                                     (' '.join([name[i.attrib['file1']], name[i.attrib['file2']]])))
                                 similar.add(name[i.attrib['file1']])
                                 similar.add(name[i.attrib['file2']])
-    return warnings, similar 
+    return warnings, similar
 
 def _slice_chr22(in_bam, data):
     """


### PR DESCRIPTION
This will show the same names than in the yaml file for qsignature final results
