### PR TITLE
Handle paths with spaces in run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,10 +11,10 @@ if [ -n "$1" ]; then
 	shift
 fi
 if [[ "$ATTR" == docker* && "`which bcbio_vm.py`" != "" ]]; then
-    BCBIO_DIR=$(dirname $(readlink -f `which bcbio_vm.py`))
+    BCBIO_DIR=$(dirname "$(readlink -f `which bcbio_vm.py`)")
 else
-    BCBIO_DIR=$(dirname $(readlink -f `which bcbio_nextgen.py`))
+    BCBIO_DIR=$(dirname "$(readlink -f `which bcbio_nextgen.py`)")
 fi
 unset PYTHONHOME
 unset PYTHONPATH
-$BCBIO_DIR/nosetests -v -s -a $ATTR "$@"
+"$BCBIO_DIR/nosetests" -v -s -a $ATTR "$@"


### PR DESCRIPTION
The absolute path to bcbio_nextgen.py may have spaces, symlinks notwithstanding. In this case, dirname tokenizes the output of readlink as multiple strings, and this propogates to the last line of the script. Quoting the path in both places fixes the problem.
