### PR TITLE
Use one consequence only with VEP if clinical_reporting is active

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -109,6 +109,21 @@ def run_vep(data):
                        "--sift", "b", "--polyphen", "b", "--symbol", "--numbers", "--biotype", "--total_length",
                        "--canonical", "--ccds",
                        "--fields", ",".join(std_fields + dbnsfp_fields + loftee_fields)] + dbnsfp_args + loftee_args
+
+                if tz.get_in(("config", "algorithm", "clinical_reporting"), data, False):
+
+                    # In case of clinical reporting, we need one and only one
+                    # variant per gene
+                    # From the VEP docs:
+                    # "Pick once line of consequence data per variant,
+                    # including transcript-specific columns. Consequences are
+                    # chosen by the canonical, biotype status and length of the
+                    # transcript, along with the ranking of the consequence
+                    # type according to this table. This is the best method to
+                    # use if you are interested only in one consequence per
+                    #  variant.
+
+                    cmd += ["--pick"]
                 cmd = "gunzip -c %s | %s | bgzip -c > %s" % (data["vrn_file"], " ".join(cmd), tx_out_file)
                 do.run(cmd, "Ensembl variant effect predictor", data)
     if utils.file_exists(out_file):


### PR DESCRIPTION
When looking for variants at the gene / exon level, sometimes it is
desirable to have only one consequence annotated, in particular for data
in clinical research. bcbio-nextgen already does this with snpEff
(-canonical option), but so far it was not used by VEP.

This patch adds this behavior (defaulting to false, hence not breaking
existing setups) when `clinical_reporting` is `true`. It does so by using 
VEP's --pick option, introduced in version 75.

From the VEP docs:

"Pick once line of consequence data per variant, including
transcript-specific columns. Consequences are chosen by the canonical,
biotype status and length of the transcript, along with the ranking of
the consequence type according to this table. This is the best method to
use if you are interested only in one consequence per variant. "

This patch has been tested on real data, and works as expected: no 
changes in pipeline workflow, and only one effect is added to the VCF as
expected when turned on.
