### PR TITLE
Import pybedtools only when it's used

### DIFF
--- a/bcbio/ngsalign/alignprep.py
+++ b/bcbio/ngsalign/alignprep.py
@@ -7,10 +7,6 @@ import shutil
 import subprocess
 
 import toolz as tz
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
 
 from bcbio import bam, utils
 from bcbio.bam import cram
@@ -165,6 +161,7 @@ def _bgzip_from_cram(cram_file, dirs, data):
     Returns a list with a single file, for single end CRAM files, or two
     files for paired end input.
     """
+    import pybedtools
     region_file = (tz.get_in(["config", "algorithm", "variant_regions"], data)
                    if tz.get_in(["config", "algorithm", "coverage_interval"], data) in ["regional", "exome"]
                    else None)

--- a/bcbio/pipeline/shared.py
+++ b/bcbio/pipeline/shared.py
@@ -5,12 +5,6 @@ from contextlib import closing, contextmanager
 import functools
 import tempfile
 
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
-import pysam
-
 from bcbio import bam, broad, utils
 from bcbio.pipeline import config_utils
 from bcbio.utils import file_exists, safe_makedir, save_diskspace
@@ -126,6 +120,7 @@ def _rewrite_bed_with_chrom(in_file, out_file, chrom):
 
 
 def _subset_bed_by_region(in_file, out_file, region, do_merge=True):
+    import pybedtools
     orig_bed = pybedtools.BedTool(in_file)
     region_bed = pybedtools.BedTool("\t".join(str(x) for x in region) + "\n", from_string=True)
     if do_merge:
@@ -143,6 +138,7 @@ def get_lcr_bed(items):
 def remove_lcr_regions(orig_bed, items):
     """If configured and available, update a BED file to remove low complexity regions.
     """
+    import pybedtools
     lcr_bed = get_lcr_bed(items)
     if lcr_bed:
         nolcr_bed = os.path.join("%s-nolcr.bed" % (utils.splitext_plus(orig_bed)[0]))
@@ -155,6 +151,7 @@ def remove_lcr_regions(orig_bed, items):
 
 @contextmanager
 def bedtools_tmpdir(data):
+    import pybedtools
     with tx_tmpdir(data) as tmpdir:
         orig_tmpdir = tempfile.gettempdir()
         pybedtools.set_tempdir(tmpdir)

--- a/bcbio/structural/ensemble.py
+++ b/bcbio/structural/ensemble.py
@@ -6,10 +6,6 @@ the evidence from each input.
 import fileinput
 import os
 
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
 import toolz as tz
 import vcf
 
@@ -45,7 +41,7 @@ def _get_svtype(rec):
 def _cnvbed_to_bed(in_file, caller, out_file):
     """Convert cn_mops CNV based bed files into flattened BED
     """
-
+    import pybedtools
     with open(out_file, "w") as out_handle:
         for feat in pybedtools.BedTool(in_file):
             out_handle.write("\t".join([feat.chrom, str(feat.start), str(feat.end),
@@ -74,6 +70,7 @@ def _create_bed(call, base_file, data):
 def summarize(calls, data):
     """Summarize results from multiple callers into a single flattened BED file.
     """
+    import pybedtools
     sample = tz.get_in(["rgnames", "sample"], data)
     work_dir = utils.safe_makedir(os.path.join(data["dirs"]["work"], "structural",
                                                sample, "ensemble"))

--- a/bcbio/structural/shared.py
+++ b/bcbio/structural/shared.py
@@ -5,10 +5,6 @@ Handles exclusion regions and preparing discordant regions.
 from contextlib import closing
 import os
 
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
 import pysam
 import toolz as tz
 
@@ -54,6 +50,7 @@ def prepare_exclude_file(items, base_file, chrom=None):
     centromere regions, both of which contribute to long run times and
     false positive structural variant calls.
     """
+    import pybedtools
     out_file = "%s-exclude.bed" % utils.splitext_plus(base_file)[0]
     all_vrs = _get_variant_regions(items)
     ready_region = (shared.subset_variant_regions(tz.first(all_vrs), chrom, base_file, items)
@@ -84,6 +81,7 @@ def prepare_exclude_file(items, base_file, chrom=None):
 def get_sv_chroms(items, exclude_file):
     """Retrieve chromosomes to process on, avoiding extra skipped chromosomes.
     """
+    import pybedtools
     exclude_regions = {}
     for region in pybedtools.BedTool(exclude_file):
         if int(region.start) == 0:

--- a/bcbio/structural/validate.py
+++ b/bcbio/structural/validate.py
@@ -11,10 +11,6 @@ import os
 import toolz as tz
 import numpy as np
 try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
-try:
     import pandas as pd
     import prettyplotlib as ppl
 except ImportError:
@@ -34,6 +30,7 @@ def _stat_str(x, n):
 def _evaluate_one(caller, svtype, size_range, ensemble, truth, exclude):
     """Compare a ensemble results for a caller against a specific caller and SV type.
     """
+    import pybedtools
     def cnv_matches(name):
         """Check for CNV matches -- XXX hardcoded for diploid comparisons.
         """

--- a/bcbio/variation/joint.py
+++ b/bcbio/variation/joint.py
@@ -12,10 +12,6 @@ import contextlib
 import math
 import os
 
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
 import pysam
 import toolz as tz
 
@@ -33,6 +29,7 @@ SUPPORTED = {"general": ["freebayes", "platypus", "samtools"],
 def _get_callable_regions(data):
     """Retrieve regions to parallelize by from callable regions, variant regions or chromosomes
     """
+    import pybedtools
     callable_files = data.get("callable_regions") or data.get("variant_regions")
     if callable_files:
         assert len(callable_files) == 1

--- a/bcbio/variation/platypus.py
+++ b/bcbio/variation/platypus.py
@@ -5,10 +5,6 @@ https://github.com/andyrimmer/Platypus
 """
 import os
 
-try:
-    import pybedtools
-except ImportError:
-    pybedtools = None
 import toolz as tz
 
 from bcbio import bam, utils
@@ -48,6 +44,7 @@ def run(align_bams, items, ref_file, assoc_files, region, out_file):
 def _bed_to_platypusin(region, base_file, items):
     """Convert BED file regions into Platypus custom inputs.
     """
+    import pybedtools
     variant_regions = bedutils.merge_overlaps(tz.get_in(["config", "algorithm", "variant_regions"], items[0]),
                                               items[0])
     target = pshared.subset_variant_regions(variant_regions, region, base_file, items)


### PR DESCRIPTION
pybedtools does something on initialization that takes ~2.5s, which makes bcbio_vm.py noticably slow for simple operations, like getting command line usage.

Along with 18601cec that I already pushed to bcbio-nextgen-vm, this patch cuts bcbio_vm.py execution time for simple operations from ~5s to ~2.5s.
