### PR TITLE
Allow mutect to accept additional parameters

### DIFF
--- a/bcbio/variation/mutect.py
+++ b/bcbio/variation/mutect.py
@@ -9,6 +9,7 @@ from bcbio import bam, broad, utils
 from bcbio.utils import file_exists, get_in, open_gzipsafe, remove_safe
 from bcbio.distributed.transaction import file_transaction
 from bcbio.variation.realign import has_aligned_reads
+from bcbio.pipeline import config_utils
 from bcbio.pipeline.shared import subset_variant_regions
 from bcbio.variation import bamprep, vcfutils, scalpel
 from bcbio.variation.vcfutils import bgzip_and_index
@@ -58,6 +59,9 @@ def _config_params(base_config, assoc_files, region, out_file):
     if region:
         params += ["-L", bamprep.region_to_gatk(region), "--interval_set_rule",
                    "INTERSECTION"]
+    resources = config_utils.get_resources("mutect", base_config)
+    if resources.get("options") is not None:
+        params += [str(x) for x in resources.get("options", [])]
     return params
 
 def _mutect_call_prep(align_bams, items, ref_file, assoc_files,


### PR DESCRIPTION
Users can now define additional parameters in the resources section of YAML.
