### PR TITLE
Vardict syntax updates

### DIFF
--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -15,7 +15,7 @@ from bcbio.provenance import do
 from bcbio.variation import annotation, bamprep, vcfutils
 
 def _vardict_options_from_config(items, config, out_file, region=None, do_merge=False):
-    opts = ["-z", "-F", "-c 1", "-S 2", "-E 3", "-g 4"]
+    opts = ["-c 1", "-S 2", "-E 3", "-g 4"]
     #["-z", "-F", "-c", "1", "-S", "2", "-E", "3", "-g", "4", "-x", "0",
     # "-k", "3", "-r", "4", "-m", "8"]
 


### PR DESCRIPTION
Hi Brad,
I've changed vardict syntax to reflect the latest codebase. Also updated the brew recipe separately. Might not need the external somatic filter anymore as with these settings VarDict doesn't output germline variants, only variants it thinks are somatic (some might not be PASSing, so it still also outputs filtered somatic variants that may have strand bias etc.)
