### PR TITLE
Viral content: calculate coverage completeness instead of read counts

### DIFF
--- a/bcbio/qc/viral.py
+++ b/bcbio/qc/viral.py
@@ -13,8 +13,12 @@ from bcbio.provenance import do
 from bcbio.variation import vcfutils
 
 def run(bam_file, data, out_dir):
-    """Run viral QC analysis.
+    """Run viral QC analysis:
+       1. Extract the unmapped reads
+       2. BWA-MEM to the viral sequences from GDC database https://gdc.cancer.gov/about-data/data-harmonization-and-generation/gdc-reference-files
+       3. Report viruses that are in more than 50% covered by at least 5x
     """
+    source_link = 'https://gdc.cancer.gov/about-data/data-harmonization-and-generation/gdc-reference-files'
     viral_target = "gdc-viral"
     out = {}
     if vcfutils.get_paired_phenotype(data):
@@ -24,24 +28,30 @@ def run(bam_file, data, out_dir):
             viral_bam = os.path.join(utils.safe_makedir(out_dir),
                                      "%s-%s.bam" % (dd.get_sample_name(data),
                                                     utils.splitext_plus(os.path.basename(viral_ref))[0]))
-            out_file = "%s-counts.txt" % utils.splitext_plus(viral_bam)[0]
+            out_file = "%s-completeness.txt" % utils.splitext_plus(viral_bam)[0]
+            cores = dd.get_num_cores(data)
             if not utils.file_uptodate(out_file, bam_file):
                 if not utils.file_uptodate(viral_bam, bam_file):
                     with file_transaction(data, viral_bam) as tx_out_file:
-                        cores = dd.get_num_cores(data)
                         tmpfile = "%s-tmp" % utils.splitext_plus(tx_out_file)[0]
                         cmd = ("samtools view -u -f 4 {bam_file} | "
                                "bamtofastq collate=0 | "
                                "bwa mem -t {cores} {viral_ref} - | "
                                "bamsort tmpfile={tmpfile} inputthreads={cores} outputthreads={cores} "
                                "inputformat=sam index=1 indexfilename={tx_out_file}.bai O={tx_out_file}")
-                        do.run(cmd.format(**locals()), "Compare unmapped reads to viral genome")
+                        do.run(cmd.format(**locals()), "Align unmapped reads to viral genome")
                 with file_transaction(data, out_file) as tx_out_file:
-                    with open(tx_out_file, "w") as out_handle:
-                        out_handle.write("# sample\t%s\n" % dd.get_sample_name(data))
-                        for info in bam.idxstats(viral_bam, data):
-                            if info.aligned > 0:
-                                out_handle.write("%s\t%s\n" % (info.contig, info.aligned))
+                    sample_name = dd.get_sample_name(data)
+                    mosdepth_prefix = os.path.splitext(viral_bam)[0]
+                    cmd = ("mosdepth -t {cores} {mosdepth_prefix} {viral_bam} -n --thresholds 1,5,25 --by "
+                           "<(awk 'BEGIN {{FS=\"\\t\"}}; {{print $1 FS \"0\" FS $2}}' {viral_ref}.fai) && "
+                           "echo '## Viral sequences (from {source_link}) found in unmapped reads' > {tx_out_file} &&"
+                           "echo '## Sample: {sample_name}' >> {tx_out_file} && "
+                           "echo '#virus\tsize\tdepth\t1x\t5x\t25x' >> {tx_out_file} && "
+                           "paste <(zcat {mosdepth_prefix}.regions.bed.gz) <(zgrep -v ^# {mosdepth_prefix}.thresholds.bed.gz) | "
+                           "awk 'BEGIN {{FS=\"\\t\"}} {{ print $1 FS $3 FS $4 FS $10/$3 FS $11/$3 FS $12/$3}}' | "
+                           "sort -n -r -k 5,5 >> {tx_out_file}")
+                    do.run(cmd.format(**locals()), "Analyse coverage of viral genomes")
             out["base"] = out_file
     return out
 


### PR DESCRIPTION
In viral stats table, bcbio reports the number of reads supporting each GDC viral sequence. This metric doesn't take into account the size of the virus; And also, in some tests I ran into viruses that contained a small repeat that attracted thousands of reads, resulting in one colossal coverage peak, with 0 coverage all along the rest of the viral sequence.

To account for those issues, I suggest to calculate coverage completeness - e.g. % viral sequence covered at 5x - and rate the viruses based on this metric instead of read count.

Will submit a corresponding MultiQC_bcbio soon.