### PR TITLE
CWL: cromwell torque "check-alive" fix

### DIFF
--- a/bcbio/cwl/hpc.py
+++ b/bcbio/cwl/hpc.py
@@ -239,7 +239,7 @@ HPC_CONFIGS = {
         ${script}
         \"\"\"
         kill = "qdel ${job_id}"
-        check-alive = "qstat -j ${job_id}"
+        check-alive = "qstat ${job_id}"
         job-id-regex = "(\\\\d+).*"
         %(filesystem)s
       }


### PR DESCRIPTION
torque `qstat` has no `-j` flag, resulting in faulty tracking of job status.