### PR TITLE
Atropos polyX trimming: disable anchored mode to allow variable length polyX stretches in 3' ends

### DIFF
--- a/bcbio/bam/trim.py
+++ b/bcbio/bam/trim.py
@@ -70,7 +70,7 @@ def _atropos_trim(fastq_files, adapters, out_dir, data):
                 tx_out2 = tx_out[2]
             # polyX trimming, anchored to the 3' ends of reads
             if "polyx" in dd.get_adapters(data):
-                adapters += ["A{200}$", "C{200}$", "G{200}$", "T{200}$"]
+                adapters += ["A{200}", "C{200}", "G{200}", "T{200}"]
             adapters_args = " ".join(["-a '%s'" % a for a in adapters])
             adapters_args += " --overlap 8"  # Avoid very short internal matches (default is 3)
             adapters_args += " --no-default-adapters --no-cache-adapters"  # Prevent GitHub queries and saving pickles


### PR DESCRIPTION
The dollar sign in the -a atropos options (`-a 'A{200}$' -a 'C{200}$' -a 'G{200}$' -a 'T{200}$'` and the corresponding `-A` options) require the adapter to be _exactly_ 200 bases long in the read 3' end. That's not the behaviour we want: we rather want it to be of _any_ length between 8 bases and 200 bases (as soon as it in the 3' end, and not in the middle of the read!). Removing $ corrects atropos behaviour to exactly the one we want:

```
test.fq:
@read1
GGGGGGGGGGGAAAAAAAAAAAAAAAAAAAAAA
```

```
atropos trim -a 'A{200}$' --overlap 8 --no-default-adapters -se test.fq
output:
@read1
GGGGGGGGGGGAAAAAAAAAAAAAAAAAAAAAA
```

```
atropos trim -a 'A{200}' --overlap 8 --no-default-adapters -se test.fq
output:
@read1
GGGGGGGGGGG
```