### PR TITLE
Set qualimap multiqc coverage cutoffs based on sample depths

### DIFF
--- a/bcbio/bam/callable.py
+++ b/bcbio/bam/callable.py
@@ -25,6 +25,7 @@ from bcbio.pipeline import shared
 from bcbio.pipeline import datadict as dd
 from bcbio.variation import coverage
 from bcbio.variation import multi as vmulti
+from bcbio.structural import regions
 
 
 def sample_callable_bed(bam_file, ref_file, data):
@@ -39,7 +40,8 @@ def sample_callable_bed(bam_file, ref_file, data):
         return r.name == "CALLABLE" and (not noalt_calling or chromhacks.is_nonalt(r.chrom))
     out_file = "%s-callable_sample.bed" % os.path.splitext(bam_file)[0]
     with shared.bedtools_tmpdir(data):
-        callable_bed, depth_files = coverage.calculate(bam_file, data)
+        sv_bed = regions.get_sv_bed(data)
+        callable_bed, depth_files = coverage.calculate(bam_file, data, sv_bed)
         input_regions_bed = dd.get_variant_regions(data)
         if not utils.file_uptodate(out_file, callable_bed):
             with file_transaction(data, out_file) as tx_out_file:

--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -256,7 +256,7 @@ def _create_config_file(out_dir, samples):
         out["table_columns_visible"]["FastQC"] = {"percent_gc": False}
 
         # Setting up thresholds for Qualimap depth cutoff calculations, based on sample avg depths
-        avg_depths = [tz.get_in(["summary", "qc", "Avg_coverage"], s) for s in samples]
+        avg_depths = [tz.get_in(["summary", "metrics", "Avg_coverage"], s) for s in samples]
         # Picking all thresholds up to the highest sample average depth
         thresholds = [t for t in coverage.DEPTH_THRESHOLDS if t <= max(avg_depths)]
         # ...plus one more
@@ -267,11 +267,11 @@ def _create_config_file(out_dir, samples):
         thresholds_hidden = []
         for i, t in enumerate(thresholds):
             if t > 20:  # Not hiding anything below 20x
-                if any(thresholds[i-1] <= c < thresholds[i+1] for c in avg_depths
-                       if c and i-1 >= 0 and i+1 < len(cov_threshs)):
+                if any(thresholds[i-1] <= c < thresholds[i] for c in avg_depths if c and i-1 >= 0) or \
+                   any(thresholds[i] <= c < thresholds[i+1] for c in avg_depths if c and i+1 < len(thresholds)):
                     pass
                 else:
-                    thresholds_hidden.add(t)
+                    thresholds_hidden.append(t)
 
         out['qualimap_config'] = {
             'general_stats_coverage': [str(t) for t in thresholds],

--- a/bcbio/variation/coverage.py
+++ b/bcbio/variation/coverage.py
@@ -19,7 +19,6 @@ from bcbio.log import logger
 from bcbio.pipeline import datadict as dd
 from bcbio.provenance import do
 from bcbio.pipeline import shared
-from bcbio.structural import regions
 from bcbio.variation import bedutils
 
 GENOME_COV_THRESH = 0.40  # percent of genome covered for whole genome analysis
@@ -71,7 +70,7 @@ def _count_offtarget(data, bam_file, bed_file, target_name):
     else:
         return 0.0
 
-def calculate(bam_file, data):
+def calculate(bam_file, data, sv_bed):
     """Calculate coverage in parallel using mosdepth.
 
     Removes duplicates and secondary reads from the counts:
@@ -89,7 +88,7 @@ def calculate(bam_file, data):
         vr_quantize = ("0:1:%s:" % (params["min"]), ["NO_COVERAGE", "LOW_COVERAGE", "CALLABLE"])
         to_calculate = [("variant_regions", variant_regions,
                          vr_quantize, None, "coverage_perbase" in dd.get_tools_on(data)),
-                        ("sv_regions", bedutils.clean_file(regions.get_sv_bed(data), data, prefix="svregions-"),
+                        ("sv_regions", bedutils.clean_file(sv_bed, data, prefix="svregions-"),
                          None, None, False),
                         ("coverage", bedutils.clean_file(dd.get_coverage(data), data, prefix="cov-"),
                          None, DEPTH_THRESHOLDS, False)]

--- a/bcbio/variation/coverage.py
+++ b/bcbio/variation/coverage.py
@@ -24,7 +24,7 @@ from bcbio.variation import bedutils
 
 GENOME_COV_THRESH = 0.40  # percent of genome covered for whole genome analysis
 OFFTARGET_THRESH = 0.01  # percent of offtarget reads required to be capture (not amplification) based
-DEPTH_THRESHOLDS = [1, 5, 10, 20, 50, 100, 250, 500, 1000, 5000, 10000, 50000]
+DEPTH_THRESHOLDS = [1,5] + sorted([k*10**exp10 for k in [1,2,5] for exp10 in range(1,6)])  # 10,20,50,100...
 
 
 def assign_interval(data):


### PR DESCRIPTION
As discussed, automatically setting thresholds when qualimap is in enabled tools.

I also had to move the `strucrual.regions` import out of the variation.coverage module to avoid circular imports `variation/coverage.py > structural/__init__.py -> structural/cn_mops.py -> structural/shared.py bam/callable.py -> variation/coverage.py`

Run a test, seems to be working.