### PR TITLE
Viral check: do for normals

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -107,7 +107,7 @@ def get_qc_tools(data):
         to_run += ["qsignature", "variants"]
         if vcfanno.is_human(data):
             to_run += ["contamination", "peddy"]
-        if vcfutils.get_paired([data]):
+        if vcfutils.get_paired_phenotype(data):
             to_run += ["viral"]
         if damage.should_filter([data]):
             to_run += ["damage"]


### PR DESCRIPTION
Often we want to see if the virus is present in a tumor sample only (which would supports its oncogenicity). How about this quick fix to check and report the viral content in normals too?