### PR TITLE
Fix parsing rRNA stats

### DIFF
--- a/bcbio/qc/qualimap.py
+++ b/bcbio/qc/qualimap.py
@@ -280,7 +280,7 @@ def _read_memoized_rrna(rrna_file):
     rrna_dict = {}
     with open(rrna_file) as in_handle:
         for line in in_handle:
-            tokens = line.split(",")
+            tokens = line.strip().split(",")
             rrna_dict[tokens[0]] = tokens[1]
     return rrna_dict
 


### PR DESCRIPTION
rRNA stats don't show up in the MultiQC report because of broken parsing. That's how they end up in `*_bcbio.txt`:

![screen shot 2018-09-04 at 17 23 06](https://user-images.githubusercontent.com/1575412/45016203-4923c080-b067-11e8-9404-8ae5ef0909b8.png)

This fixes it by stripping `\n` in the end of lines.

cc @ohofmann 