### PR TITLE
Fix getting input files for non-flat input structure

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -224,7 +224,7 @@ def _get_input_files(samples, base_dir, tx_out_dir):
             # CWL: presents output files as single file plus associated secondary files
             elif isinstance(pfiles, basestring):
                 if os.path.exists(pfiles):
-                    pfiles = [os.path.join(os.path.dirname(pfiles), x) for x in os.listdir(os.path.dirname(pfiles))]
+                    pfiles = [os.path.join(basedir, f) for basedir, subdir, filenames in os.walk(os.path.dirname(pfiles)) for f in filenames]
                 else:
                     pfiles = []
             in_files[(dd.get_sample_name(data), program)].extend(pfiles)


### PR DESCRIPTION
Hi @chapmanb I was testing the test-bcbio-cwl workflows and some of them fail on rabix and SBG platform on multiqc step. I think the reason for this is because the secondary input files from some qc steps are created in subfolders relative to the primary file. When these files are mounted in the docker container in cwltool the structure is flattened, while in rabix/sbg docker containers the original structure is preserved. This modification should handle both cases. Tested with rabix and cwltool.