### PR TITLE
fix #2520: logging in parallel threads (local multi-core)

### DIFF
--- a/bcbio/distributed/multi.py
+++ b/bcbio/distributed/multi.py
@@ -83,7 +83,7 @@ def run_multicore(fn, items, config, parallel=None):
     if joblib is None:
         raise ImportError("Need joblib for multiprocessing parallelization")
     out = []
-    for data in joblib.Parallel(parallel["num_jobs"], batch_size=1)(joblib.delayed(fn)(x) for x in items):
+    for data in joblib.Parallel(parallel["num_jobs"], batch_size=1, backend="multiprocessing")(joblib.delayed(fn)(x) for x in items):
         if data:
             out.extend(data)
     return out


### PR DESCRIPTION
In the transition from 0.11 to 0.12 joblib moved to a new default backend (`loky`) that does not work with the logging setup for local parallel setups (multi-core) via logbook.Logger and handlers communicating via a queue. The problem persists with the new `joblib` version released yesterday, `0.13`.

This fix enforces the previous default backend, `multiprocessing`, which spawns several processes of the python interpreter and seems the only parallel execution scheme that currently works w.r.t.
logging in a local parallel execution. See https://media.readthedocs.org/pdf/joblib/latest/joblib.pdf and
https://github.com/joblib/joblib/blob/4f1ca521480713c403e1ddd362af43def6a059c8/joblib/parallel.py#L40. 

It has been tested both in docker setups and running outside a container.