### PR TITLE
Fix qsignature for multiqc

### DIFF
--- a/bcbio/pipeline/qcsummary.py
+++ b/bcbio/pipeline/qcsummary.py
@@ -39,7 +39,6 @@ def generate_parallel(samples, run_parallel):
     qced = run_parallel("pipeline_summary", to_analyze)
     samples = _combine_qc_samples(qced) + extras
     qsign_info = run_parallel("qsignature_summary", [samples])
-    samples = run_parallel("multiqc_summary", [samples])
     metadata_file = _merge_metadata([samples])
     summary_file = write_project_summary(samples, qsign_info)
     out = []
@@ -52,6 +51,8 @@ def generate_parallel(samples, run_parallel):
             data[0]["summary"]["mixup_check"] = qsign_info[0]["out_dir"]
         out.append(data)
     out = _add_researcher_summary(out, summary_file)
+    # MultiQC must be run after all file outputs are set:
+    run_parallel("multiqc_summary", [samples])
     return out
 
 def pipeline_summary(data):

--- a/bcbio/qc/qsignature.py
+++ b/bcbio/qc/qsignature.py
@@ -117,6 +117,11 @@ def summary(*samples):
     else:
         return []
 
+def get_qsig_multiqc_files(*samples):
+    work_dir = samples[0][0]["dirs"]["work"]
+    qc_out_dir = utils.safe_makedir(os.path.join(work_dir, "qc", "qsignature"))
+    return [os.path.join(qc_out_dir, "qsignature.ma")]
+
 def _parse_qsignature_output(in_file, out_file, warning_file, data):
     """ Parse xml file produced by qsignature
 


### PR DESCRIPTION
Fixing uploading qsignature .ma file to propagate it into multiqc_bcbio:
- summarize qsignature _before_ running MultiQC so all files are in place
- add qsignature.ma into multiqc file list
- multiqc file_list_final: support dirs to propagate mixup_check with qsignature.ma file

Though later realized that qsignature reporting in MultiQC is commented out: https://github.com/MultiQC/MultiQC_bcbio/pull/24