### PR TITLE
WIP Avoid adding directories to secondaryFiles with class File

### DIFF
--- a/bcbio/distributed/runfn.py
+++ b/bcbio/distributed/runfn.py
@@ -578,11 +578,11 @@ def _to_cwl(val, input_files):
             if cur_file.endswith(cwlutils.DIR_TARGETS):
                 if os.path.exists(cur_dir):
                     for fname in os.listdir(cur_dir):
-                        if fname != cur_file:
+                        if fname != cur_file and os.path.isfile(fname):
                             secondary.append({"class": "File", "path": os.path.join(cur_dir, fname)})
                 else:
                     for f in input_files:
-                        if f.startswith(cur_dir) and f != cur_file:
+                        if f.startswith(cur_dir) and f != cur_file and os.path.isfile(f):
                             secondary.append({"class": "File", "path": f})
             if secondary:
                 val["secondaryFiles"] = _remove_duplicate_files(secondary)

--- a/bcbio/distributed/runfn.py
+++ b/bcbio/distributed/runfn.py
@@ -582,7 +582,7 @@ def _to_cwl(val, input_files):
                             secondary.append({"class": "File", "path": os.path.join(cur_dir, fname)})
                 else:
                     for f in input_files:
-                        if f.startswith(cur_dir) and f != cur_file and os.path.isfile(f):
+                        if f.startswith(cur_dir) and f != cur_file:
                             secondary.append({"class": "File", "path": f})
             if secondary:
                 val["secondaryFiles"] = _remove_duplicate_files(secondary)

--- a/bcbio/distributed/runfn.py
+++ b/bcbio/distributed/runfn.py
@@ -578,7 +578,7 @@ def _to_cwl(val, input_files):
             if cur_file.endswith(cwlutils.DIR_TARGETS):
                 if os.path.exists(cur_dir):
                     for fname in os.listdir(cur_dir):
-                        if fname != cur_file and os.path.isfile(fname):
+                        if fname != cur_file and not os.path.isdir(fname):
                             secondary.append({"class": "File", "path": os.path.join(cur_dir, fname)})
                 else:
                     for f in input_files:


### PR DESCRIPTION
Depending on the file structure for inputs, directories might be present in the same folder with primary file (which actually happens in SBG execution) but they are added with with `"class": "File"`. This fix avoids adding these directories to the secondary file list.