### PR TITLE
#2618: fix qc/variants/*_bcftools file creation

### DIFF
--- a/bcbio/qc/variant.py
+++ b/bcbio/qc/variant.py
@@ -117,9 +117,10 @@ def get_active_vcinfo(data, use_ensemble=True):
     """
     active_vs = _get_variants(data)
     if len(active_vs) > 0:
+        e_active_vs = []
         if use_ensemble:
             e_active_vs = [v for v in active_vs if v.get("variantcaller") == "ensemble"]
-        else:
+        if len(e_active_vs) == 0:
             e_active_vs = [v for v in active_vs if v.get("variantcaller") != "ensemble"]
         if len(e_active_vs) > 0:
             return e_active_vs[0]


### PR DESCRIPTION
These files are not created anymore because `get_active_vcinfo`
returns an empty array instead of the first element on invocation
when running a non-ensemble setup.

Instead, it now fails 'gracefully' by attempting to find an entry for
the 'ensemble' variant caller, but if it does not find one it will still
return the first non-ensemble one.