### PR TITLE
Fix for GC field with multiple values in gnomad VCFs

### DIFF
--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -1,4 +1,4 @@
-version: 48
+version: 49
 
 aliases:
   human: true
@@ -16,6 +16,7 @@ variation:
   esp: ../variation/esp.vcf.gz
   exac: ../variation/exac.vcf.gz
   gnomad_exome: ../variation/gnomad_exome.vcf.gz
+  gnomad_genome: ../variation/gnomad_genome.vcf.gz
   1000g: ../variation/1000g.vcf.gz
   lcr: ../coverage/problem_regions/repeats/LCR.bed.gz
   polyx: ../coverage/problem_regions/repeats/polyx.bed.gz

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -1,4 +1,4 @@
-version: 50
+version: 51
 
 aliases:
   human: true
@@ -16,6 +16,7 @@ variation:
   esp: ../variation/esp.vcf.gz
   exac: ../variation/exac.vcf.gz
   gnomad_exome: ../variation/gnomad_exome.vcf.gz
+  gnomad_genome: ../variation/gnomad_genome.vcf.gz
   1000g: ../variation/1000g.vcf.gz
   lcr: ../coverage/problem_regions/repeats/LCR.bed.gz
   polyx: ../coverage/problem_regions/repeats/polyx.bed.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -1,4 +1,4 @@
-version: 34
+version: 35
 
 aliases:
   human: true
@@ -18,6 +18,7 @@ variation:
   esp: ../variation/esp.vcf.gz
   exac: ../variation/exac.vcf.gz
   gnomad_exome: ../variation/gnomad_exome.vcf.gz
+  gnomad_genome: ../variation/gnomad_genome.vcf.gz
   lcr: ../coverage/problem_regions/repeats/LCR.bed.gz
   polyx: ../coverage/problem_regions/repeats/polyx.bed.gz
   gc_profile: ../coverage/gc/GC_profile.1000bp.cnp

--- a/config/vcfanno/GRCh37-gemini.conf
+++ b/config/vcfanno/GRCh37-gemini.conf
@@ -10,7 +10,7 @@ ops=["max", "self", "max", "self", "max", "self", "max", "self", "max", "self", 
 file="variation/gnomad_exome.vcf.gz"
 fields=["AF","AF_AFR","AF_AMR","AF_ASJ","AF_EAS","AF_FIN","AF_NFE","AF_OTH","AF_SAS","AF_POPMAX","AC","AC_ACR","AC_AMR","AC_ASJ","AC_EAS","AC_FIN","AC_NFE","AC_OTH","AC_SAS","AC_POPMAX","AN","AN_ANR","AN_AMR","AN_ASJ","AN_EAS","AN_FIN","AN_NFE","AN_OTH","AN_SAS","AN_POPMAX","POPMAX","GC","GC_Male","GC_Female","Hom","Hom_Male","Hom_Female"]
 names=["gnomAD_AF","gnomAD_AF_AFR","gnomAD_AF_AMR","gnomAD_AF_ASJ","gnomAD_AF_EAS","gnomAD_AF_FIN","gnomAD_AF_NFE","gnomAD_AF_OTH","gnomAD_AF_SAS","gnomAD_AF_POPMAX","gnomAD_AC","gnomAD_AC_ACR","gnomAD_AC_AMR","gnomAD_AC_ASJ","gnomAD_AC_EAS","gnomAD_AC_FIN","gnomAD_AC_NFE","gnomAD_AC_OTH","gnomAD_AC_SAS","gnomAD_AC_POPMAX","gnomAD_AN","gnomAD_AN_ANR","gnomAD_AN_AMR","gnomAD_AN_ASJ","gnomAD_AN_EAS","gnomAD_AN_FIN","gnomAD_AN_NFE","gnomAD_AN_OTH","gnomAD_AN_SAS","gnomAD_AN_POPMAX","gnomAD_POPMAX","gnomAD_GC","gnomAD_GC_Male","gnomAD_GC_Female","gnomAD_Hom","gnomAD_Hom_Male","gnomAD_Hom_Female"]
-ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self"]
+ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","sum","sum","sum","self","self","self"]
 
 
 [[annotation]]

--- a/config/vcfanno/GRCh37-gnomad_genome.conf
+++ b/config/vcfanno/GRCh37-gnomad_genome.conf
@@ -2,7 +2,7 @@
 file="variation/gnomad_genome.vcf.gz"
 fields=["AF","AF_AFR","AF_AMR","AF_ASJ","AF_EAS","AF_FIN","AF_NFE","AF_OTH","AF_SAS","AF_POPMAX","AC","AC_ACR","AC_AMR","AC_ASJ","AC_EAS","AC_FIN","AC_NFE","AC_OTH","AC_SAS","AC_POPMAX","AN","AN_ANR","AN_AMR","AN_ASJ","AN_EAS","AN_FIN","AN_NFE","AN_OTH","AN_SAS","AN_POPMAX","POPMAX","GC","GC_Male","GC_Female","Hom","Hom_Male","Hom_Female"]
 names=["gnomAD_AF","gnomAD_AF_AFR","gnomAD_AF_AMR","gnomAD_AF_ASJ","gnomAD_AF_EAS","gnomAD_AF_FIN","gnomAD_AF_NFE","gnomAD_AF_OTH","gnomAD_AF_SAS","gnomAD_AF_POPMAX","gnomAD_AC","gnomAD_AC_ACR","gnomAD_AC_AMR","gnomAD_AC_ASJ","gnomAD_AC_EAS","gnomAD_AC_FIN","gnomAD_AC_NFE","gnomAD_AC_OTH","gnomAD_AC_SAS","gnomAD_AC_POPMAX","gnomAD_AN","gnomAD_AN_ANR","gnomAD_AN_AMR","gnomAD_AN_ASJ","gnomAD_AN_EAS","gnomAD_AN_FIN","gnomAD_AN_NFE","gnomAD_AN_OTH","gnomAD_AN_SAS","gnomAD_AN_POPMAX","gnomAD_POPMAX","gnomAD_GC","gnomAD_GC_Male","gnomAD_GC_Female","gnomAD_Hom","gnomAD_Hom_Male","gnomAD_Hom_Female"]
-ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self"]
+ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","sum","sum","sum","self","self","self"]
 
 #Possible Fields
 #AC_AFR: "Allele count in African/African American genotypes, for each ALT allele, in the same order as listed"

--- a/config/vcfanno/hg38-gemini.conf
+++ b/config/vcfanno/hg38-gemini.conf
@@ -10,7 +10,7 @@ ops=["max", "max", "max", "max", "max", "max", "max", "max", "max", "max", "max"
 file="variation/gnomad_exome.vcf.gz"
 fields=["AF","AF_AFR","AF_AMR","AF_ASJ","AF_EAS","AF_FIN","AF_NFE","AF_OTH","AF_SAS","AF_POPMAX","AC","AC_ACR","AC_AMR","AC_ASJ","AC_EAS","AC_FIN","AC_NFE","AC_OTH","AC_SAS","AC_POPMAX","AN","AN_ANR","AN_AMR","AN_ASJ","AN_EAS","AN_FIN","AN_NFE","AN_OTH","AN_SAS","AN_POPMAX","POPMAX","GC","GC_Male","GC_Female","Hom","Hom_Male","Hom_Female"]
 names=["gnomAD_AF","gnomAD_AF_AFR","gnomAD_AF_AMR","gnomAD_AF_ASJ","gnomAD_AF_EAS","gnomAD_AF_FIN","gnomAD_AF_NFE","gnomAD_AF_OTH","gnomAD_AF_SAS","gnomAD_AF_POPMAX","gnomAD_AC","gnomAD_AC_ACR","gnomAD_AC_AMR","gnomAD_AC_ASJ","gnomAD_AC_EAS","gnomAD_AC_FIN","gnomAD_AC_NFE","gnomAD_AC_OTH","gnomAD_AC_SAS","gnomAD_AC_POPMAX","gnomAD_AN","gnomAD_AN_ANR","gnomAD_AN_AMR","gnomAD_AN_ASJ","gnomAD_AN_EAS","gnomAD_AN_FIN","gnomAD_AN_NFE","gnomAD_AN_OTH","gnomAD_AN_SAS","gnomAD_AN_POPMAX","gnomAD_POPMAX","gnomAD_GC","gnomAD_GC_Male","gnomAD_GC_Female","gnomAD_Hom","gnomAD_Hom_Male","gnomAD_Hom_Female"]
-ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self"]
+ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","sum","sum","sum","self","self","self"]
 
 [[annotation]]
 file="variation/esp.vcf.gz"

--- a/config/vcfanno/hg38-gnomad_genome.conf
+++ b/config/vcfanno/hg38-gnomad_genome.conf
@@ -2,7 +2,7 @@
 file="variation/gnomad_genome.vcf.gz"
 fields=["AF","AF_AFR","AF_AMR","AF_ASJ","AF_EAS","AF_FIN","AF_NFE","AF_OTH","AF_SAS","AF_POPMAX","AC","AC_ACR","AC_AMR","AC_ASJ","AC_EAS","AC_FIN","AC_NFE","AC_OTH","AC_SAS","AC_POPMAX","AN","AN_ANR","AN_AMR","AN_ASJ","AN_EAS","AN_FIN","AN_NFE","AN_OTH","AN_SAS","AN_POPMAX","POPMAX","GC","GC_Male","GC_Female","Hom","Hom_Male","Hom_Female"]
 names=["gnomAD_AF","gnomAD_AF_AFR","gnomAD_AF_AMR","gnomAD_AF_ASJ","gnomAD_AF_EAS","gnomAD_AF_FIN","gnomAD_AF_NFE","gnomAD_AF_OTH","gnomAD_AF_SAS","gnomAD_AF_POPMAX","gnomAD_AC","gnomAD_AC_ACR","gnomAD_AC_AMR","gnomAD_AC_ASJ","gnomAD_AC_EAS","gnomAD_AC_FIN","gnomAD_AC_NFE","gnomAD_AC_OTH","gnomAD_AC_SAS","gnomAD_AC_POPMAX","gnomAD_AN","gnomAD_AN_ANR","gnomAD_AN_AMR","gnomAD_AN_ASJ","gnomAD_AN_EAS","gnomAD_AN_FIN","gnomAD_AN_NFE","gnomAD_AN_OTH","gnomAD_AN_SAS","gnomAD_AN_POPMAX","gnomAD_POPMAX","gnomAD_GC","gnomAD_GC_Male","gnomAD_GC_Female","gnomAD_Hom","gnomAD_Hom_Male","gnomAD_Hom_Female"]
-ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self"]
+ops=["self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","self","sum","sum","sum","self","self","self"]
 
 #Possible Fields
 #AC_AFR: "Allele count in African/African American genotypes, for each ALT allele, in the same order as listed"


### PR DESCRIPTION
Hi @chapmanb,

When running `bcbio-nextgen` (latest dev version) on 6 human WGS samples, hg38, with `gemini` DB creation via `vcf2db` and with the VCFs annotated using `vcfanno` from several resources, including `gnomad_genome.vcf.gz`, it crashes when creating the `gemini` DBs with the following error:

```
[2019-01-17T01:39Z] GEMINI: create database with vcf2db
[2019-01-17T01:39Z] /usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/sqlalchemy/sql/sqltypes.py:258: SAWarning: Unicode type received non-unicode bind param value ''. (this warning may be suppressed after 10 occurrences)
[2019-01-17T01:39Z]   (util.ellipses_string(value),),
[2019-01-17T01:39Z] /usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/sqlalchemy/sql/sqltypes.py:258: SAWarning: Unicode type received non-unicode bind param value '-9'. (this warning may be suppressed after 10 occurrences)
[2019-01-17T01:39Z]   (util.ellipses_string(value),),
[2019-01-17T01:40Z] bad record:
[2019-01-17T01:40Z] AC 2
[2019-01-17T01:40Z] AF 1.0
[2019-01-17T01:40Z] AN 2
[2019-01-17T01:40Z] AltaiNeandertal None
[2019-01-17T01:40Z] Ancestral_allele None
[2019-01-17T01:40Z] BaseQRankSum -1.10300004482
[2019-01-17T01:40Z] CADD_phred None
[2019-01-17T01:40Z] CADD_raw None
[2019-01-17T01:40Z] CADD_raw_rankscore None
[2019-01-17T01:40Z] CSQ None
[2019-01-17T01:40Z] ClippingRankSum 0.0
[2019-01-17T01:40Z] DANN_rankscore None
[2019-01-17T01:40Z] DANN_score None
[2019-01-17T01:40Z] DB None
[2019-01-17T01:40Z] DECOMPOSED None
[2019-01-17T01:40Z] DP 18
[2019-01-17T01:40Z] Denisova None
[2019-01-17T01:40Z] Eigen-PC-phred None
[2019-01-17T01:40Z] Eigen-PC-raw None
[2019-01-17T01:40Z] Eigen-PC-raw_rankscore None
[2019-01-17T01:40Z] Eigen-phred None
[2019-01-17T01:40Z] Eigen-raw None
[2019-01-17T01:40Z] Eigen_coding_or_noncoding None
[2019-01-17T01:40Z] Ensembl? None
[2019-01-17T01:40Z] Ensembl_functional_consequence None
[2019-01-17T01:40Z] Ensembl_gene None
[2019-01-17T01:40Z] Ensembl_geneid None
[2019-01-17T01:40Z] Ensembl_id_c.change_p.change None
[2019-01-17T01:40Z] Ensembl_proteinid None
[2019-01-17T01:40Z] Ensembl_region None
[2019-01-17T01:40Z] Ensembl_transcriptid None
[2019-01-17T01:40Z] ExcessHet 3.01029992104
[2019-01-17T01:40Z] FATHMM_converted_rankscore None
[2019-01-17T01:40Z] FATHMM_pred None
[2019-01-17T01:40Z] FATHMM_score None
[2019-01-17T01:40Z] FS 0.0
[2019-01-17T01:40Z] GERP++_NR None
[2019-01-17T01:40Z] GERP++_RS None
[2019-01-17T01:40Z] GERP++_RS_rankscore None
[2019-01-17T01:40Z] GM12878_confidence_value None
[2019-01-17T01:40Z] GM12878_fitCons_score None
[2019-01-17T01:40Z] GM12878_fitCons_score_rankscore None
[2019-01-17T01:40Z] GTEx_V6p_gene None
[2019-01-17T01:40Z] GTEx_V6p_tissue None
[2019-01-17T01:40Z] GenoCanyon_score None
[2019-01-17T01:40Z] GenoCanyon_score_rankscore None
[2019-01-17T01:40Z] H1-hESC_confidence_value None
[2019-01-17T01:40Z] H1-hESC_fitCons_score None
[2019-01-17T01:40Z] H1-hESC_fitCons_score_rankscore None
[2019-01-17T01:40Z] HUVEC_confidence_value None
[2019-01-17T01:40Z] HUVEC_fitCons_score None
[2019-01-17T01:40Z] HUVEC_fitCons_score_rankscore None
[2019-01-17T01:40Z] Interpro_domain None
[2019-01-17T01:40Z] LEN None
[2019-01-17T01:40Z] LRT_Omega None
[2019-01-17T01:40Z] LRT_converted_rankscore None
[2019-01-17T01:40Z] LRT_pred None
[2019-01-17T01:40Z] LRT_score None
[2019-01-17T01:40Z] M-CAP_pred None
[2019-01-17T01:40Z] M-CAP_rankscore None
[2019-01-17T01:40Z] M-CAP_score None
[2019-01-17T01:40Z] MLEAC 2
[2019-01-17T01:40Z] MLEAF 1.0
[2019-01-17T01:40Z] MQ 33.2099990845
[2019-01-17T01:40Z] MQ0 0
[2019-01-17T01:40Z] MQRankSum -1.22099995613
[2019-01-17T01:40Z] MetaLR_pred None
[2019-01-17T01:40Z] MetaLR_rankscore None
[2019-01-17T01:40Z] MetaLR_score None
[2019-01-17T01:40Z] MetaSVM_pred None
[2019-01-17T01:40Z] MetaSVM_rankscore None
[2019-01-17T01:40Z] MetaSVM_score None
[2019-01-17T01:40Z] MutPred_AAchange None
[2019-01-17T01:40Z] MutPred_Top5features None
[2019-01-17T01:40Z] MutPred_protID None
[2019-01-17T01:40Z] MutPred_rankscore None
[2019-01-17T01:40Z] MutPred_score None
[2019-01-17T01:40Z] MutationAssessor_UniprotID None
[2019-01-17T01:40Z] MutationAssessor_pred None
[2019-01-17T01:40Z] MutationAssessor_score None
[2019-01-17T01:40Z] MutationAssessor_score_rankscore None
[2019-01-17T01:40Z] MutationAssessor_variant None
[2019-01-17T01:40Z] MutationTaster_AAE None
[2019-01-17T01:40Z] MutationTaster_converted_rankscore None
[2019-01-17T01:40Z] MutationTaster_model None
[2019-01-17T01:40Z] MutationTaster_pred None
[2019-01-17T01:40Z] MutationTaster_score None
[2019-01-17T01:40Z] NEGATIVE_TRAIN_SITE None
[2019-01-17T01:40Z] OLD_MULTIALLELIC None
[2019-01-17T01:40Z] OLD_VARIANT None
[2019-01-17T01:40Z] POSITIVE_TRAIN_SITE None
[2019-01-17T01:40Z] PROVEAN_converted_rankscore None
[2019-01-17T01:40Z] PROVEAN_pred None
[2019-01-17T01:40Z] PROVEAN_score None
[2019-01-17T01:40Z] QD 1.67999994755
[2019-01-17T01:40Z] REVEL_rankscore None
[2019-01-17T01:40Z] REVEL_score None
[2019-01-17T01:40Z] ReadPosRankSum 1.21099996567
[2019-01-17T01:40Z] RefSeq? None
[2019-01-17T01:40Z] RefSeq_functional_consequence None
[2019-01-17T01:40Z] RefSeq_gene None
[2019-01-17T01:40Z] RefSeq_id_c.change_p.change None
[2019-01-17T01:40Z] RefSeq_region None
[2019-01-17T01:40Z] Reliability_index None
[2019-01-17T01:40Z] SOR 0.592999994755
[2019-01-17T01:40Z] SiPhy_29way_logOdds None
[2019-01-17T01:40Z] SiPhy_29way_logOdds_rankscore None
[2019-01-17T01:40Z] SiPhy_29way_pi None
[2019-01-17T01:40Z] TYPE None
[2019-01-17T01:40Z] Transcript_id_VEST3 None
[2019-01-17T01:40Z] Transcript_var_VEST3 None
[2019-01-17T01:40Z] VEST3_rankscore None
[2019-01-17T01:40Z] VEST3_score None
[2019-01-17T01:40Z] VQSLOD 3.88000011444
[2019-01-17T01:40Z] aa_af
[2019-01-17T01:40Z] aa_change
[2019-01-17T01:40Z] aa_length
[2019-01-17T01:40Z] aaf 1.0
[2019-01-17T01:40Z] ac 2
[2019-01-17T01:40Z] ac_adj_exac_afr None
[2019-01-17T01:40Z] ac_adj_exac_amr None
[2019-01-17T01:40Z] ac_adj_exac_eas None
[2019-01-17T01:40Z] ac_adj_exac_fin None
[2019-01-17T01:40Z] ac_adj_exac_nfe None
[2019-01-17T01:40Z] ac_adj_exac_oth None
[2019-01-17T01:40Z] ac_adj_exac_sas None
[2019-01-17T01:40Z] ac_exac_all None
[2019-01-17T01:40Z] ada_score None
[2019-01-17T01:40Z] af
[2019-01-17T01:40Z] af_adj_exac_afr -1.0
[2019-01-17T01:40Z] af_adj_exac_amr -1.0
[2019-01-17T01:40Z] af_adj_exac_eas -1.0
[2019-01-17T01:40Z] af_adj_exac_fin -1.0
[2019-01-17T01:40Z] af_adj_exac_nfe -1.0
[2019-01-17T01:40Z] af_adj_exac_oth -1.0
[2019-01-17T01:40Z] af_adj_exac_sas -1.0
[2019-01-17T01:40Z] af_esp_aa -1.0
[2019-01-17T01:40Z] af_esp_all -1.0
[2019-01-17T01:40Z] af_esp_ea -1.0
[2019-01-17T01:40Z] af_exac_all -1.0
[2019-01-17T01:40Z] afr_af
[2019-01-17T01:40Z] allele -
[2019-01-17T01:40Z] allele_num 1
[2019-01-17T01:40Z] alt C
[2019-01-17T01:40Z] altaineandertal None
[2019-01-17T01:40Z] amr_af
[2019-01-17T01:40Z] an 2
[2019-01-17T01:40Z] an_adj_exac_afr -1.0
[2019-01-17T01:40Z] an_adj_exac_amr -1.0
[2019-01-17T01:40Z] an_adj_exac_eas -1.0
[2019-01-17T01:40Z] an_adj_exac_fin -1.0
[2019-01-17T01:40Z] an_adj_exac_nfe -1.0
[2019-01-17T01:40Z] an_adj_exac_oth -1.0
[2019-01-17T01:40Z] an_adj_exac_sas -1.0
[2019-01-17T01:40Z] an_exac_all -1.0
[2019-01-17T01:40Z] ancestral_allele None
[2019-01-17T01:40Z] appris
[2019-01-17T01:40Z] bam_edit
[2019-01-17T01:40Z] baseqranksum -1.10300004482
[2019-01-17T01:40Z] biotype processed_transcript
[2019-01-17T01:40Z] cadd_phred None
[2019-01-17T01:40Z] cadd_raw None
[2019-01-17T01:40Z] cadd_raw_rankscore None
[2019-01-17T01:40Z] call_rate 1.0
[2019-01-17T01:40Z] ccds
[2019-01-17T01:40Z] cdna_position
[2019-01-17T01:40Z] cds_position
[2019-01-17T01:40Z] cds_strand None
[2019-01-17T01:40Z] chrom chr1
[2019-01-17T01:40Z] clin_sig
[2019-01-17T01:40Z] clinvar_disease_name None
[2019-01-17T01:40Z] clinvar_sig None
[2019-01-17T01:40Z] clippingranksum 0.0
[2019-01-17T01:40Z] codon_change
[2019-01-17T01:40Z] codon_degeneracy None
[2019-01-17T01:40Z] codonpos None
[2019-01-17T01:40Z] common_pathogenic False
[2019-01-17T01:40Z] csq None
[2019-01-17T01:40Z] culprit QD
[2019-01-17T01:40Z] dann_rankscore None
[2019-01-17T01:40Z] dann_score None
[2019-01-17T01:40Z] db False
[2019-01-17T01:40Z] decomposed False
[2019-01-17T01:40Z] denisova None
[2019-01-17T01:40Z] distance 1689
[2019-01-17T01:40Z] domains
[2019-01-17T01:40Z] dp 18
[2019-01-17T01:40Z] ds False
[2019-01-17T01:40Z] ea_af
[2019-01-17T01:40Z] eas_af
[2019-01-17T01:40Z] effect_severity LOW
[2019-01-17T01:40Z] eigen_coding_or_noncoding None
[2019-01-17T01:40Z] eigen_pc_phred None
[2019-01-17T01:40Z] eigen_pc_raw None
[2019-01-17T01:40Z] eigen_pc_raw_rankscore None
[2019-01-17T01:40Z] eigen_phred None
[2019-01-17T01:40Z] eigen_raw None
[2019-01-17T01:40Z] end 10180
[2019-01-17T01:40Z] ensembl? None
[2019-01-17T01:40Z] ensembl_functional_consequence None
[2019-01-17T01:40Z] ensembl_gene None
[2019-01-17T01:40Z] ensembl_gene_id None
[2019-01-17T01:40Z] ensembl_geneid None
[2019-01-17T01:40Z] ensembl_id_c_change_p_change None
[2019-01-17T01:40Z] ensembl_proteinid None
[2019-01-17T01:40Z] ensembl_region None
[2019-01-17T01:40Z] ensembl_transcriptid None
[2019-01-17T01:40Z] ensp
[2019-01-17T01:40Z] eur_af
[2019-01-17T01:40Z] excesshet 3.01029992104
[2019-01-17T01:40Z] existing_variation rs1367957502
[2019-01-17T01:40Z] exon
[2019-01-17T01:40Z] fathmm-MKL_coding_group None
[2019-01-17T01:40Z] fathmm-MKL_coding_pred None
[2019-01-17T01:40Z] fathmm-MKL_coding_rankscore None
[2019-01-17T01:40Z] fathmm-MKL_coding_score None
[2019-01-17T01:40Z] fathmm_converted_rankscore None
[2019-01-17T01:40Z] fathmm_mkl_coding_group None
[2019-01-17T01:40Z] fathmm_mkl_coding_pred None
[2019-01-17T01:40Z] fathmm_mkl_coding_rankscore None
[2019-01-17T01:40Z] fathmm_mkl_coding_score None
[2019-01-17T01:40Z] fathmm_pred None
[2019-01-17T01:40Z] fathmm_score None
[2019-01-17T01:40Z] feature_type Transcript
[2019-01-17T01:40Z] filter None
[2019-01-17T01:40Z] flags
[2019-01-17T01:40Z] fs 0.0
[2019-01-17T01:40Z] gene DDX11L1
[2019-01-17T01:40Z] gene_pheno
[2019-01-17T01:40Z] genocanyon_score None
[2019-01-17T01:40Z] genocanyon_score_rankscore None
[2019-01-17T01:40Z] gerp++_nr None
[2019-01-17T01:40Z] gerp++_rs None
[2019-01-17T01:40Z] gerp++_rs_rankscore None
[2019-01-17T01:40Z] given_ref TAACCCTAACCT
[2019-01-17T01:40Z] gm12878_confidence_value None
[2019-01-17T01:40Z] gm12878_fitcons_score None
[2019-01-17T01:40Z] gm12878_fitcons_score_rankscore None
[2019-01-17T01:40Z] gnomAD_AC 6
[2019-01-17T01:40Z] gnomAD_AC_AMR 0
[2019-01-17T01:40Z] gnomAD_AC_ASJ 0
[2019-01-17T01:40Z] gnomAD_AC_EAS 0
[2019-01-17T01:40Z] gnomAD_AC_FIN 0
[2019-01-17T01:40Z] gnomAD_AC_NFE 3
[2019-01-17T01:40Z] gnomAD_AC_OTH 0
[2019-01-17T01:40Z] gnomAD_AC_POPMAX 3
[2019-01-17T01:40Z] gnomAD_AF 0.000466560013592
[2019-01-17T01:40Z] gnomAD_AF_AFR 0.000860590022057
[2019-01-17T01:40Z] gnomAD_AF_AMR 0.0
[2019-01-17T01:40Z] gnomAD_AF_ASJ 0.0
[2019-01-17T01:40Z] gnomAD_AF_EAS 0.0
[2019-01-17T01:40Z] gnomAD_AF_FIN 0.0
[2019-01-17T01:40Z] gnomAD_AF_NFE 0.000490200007334
[2019-01-17T01:40Z] gnomAD_AF_OTH 0.0
[2019-01-17T01:40Z] gnomAD_AF_POPMAX 0.000860590022057
[2019-01-17T01:40Z] gnomAD_AN 12860
[2019-01-17T01:40Z] gnomAD_AN_AMR 398
[2019-01-17T01:40Z] gnomAD_AN_ASJ 172
[2019-01-17T01:40Z] gnomAD_AN_EAS 666
[2019-01-17T01:40Z] gnomAD_AN_FIN 1632
[2019-01-17T01:40Z] gnomAD_AN_NFE 6120
[2019-01-17T01:40Z] gnomAD_AN_OTH 386
[2019-01-17T01:40Z] gnomAD_AN_POPMAX 3486
[2019-01-17T01:40Z] gnomAD_GC (6414, 6, 0)
[2019-01-17T01:40Z] gnomAD_GC_Female (2805, 2, 0)
[2019-01-17T01:40Z] gnomAD_GC_Male (3609, 4, 0)
[2019-01-17T01:40Z] gnomAD_exomes_AC None
[2019-01-17T01:40Z] gnomAD_exomes_AF None
[2019-01-17T01:40Z] gnomAD_exomes_AN None
[2019-01-17T01:40Z] gnomAD_genomes_AC None
[2019-01-17T01:40Z] gnomAD_genomes_AF None
[2019-01-17T01:40Z] gnomAD_genomes_AN None
[2019-01-17T01:40Z] gnomad_ac 6
[2019-01-17T01:40Z] gnomad_ac_amr 0
[2019-01-17T01:40Z] gnomad_ac_asj 0
[2019-01-17T01:40Z] gnomad_ac_eas 0
[2019-01-17T01:40Z] gnomad_ac_fin 0
[2019-01-17T01:40Z] gnomad_ac_nfe 3
[2019-01-17T01:40Z] gnomad_ac_oth 0
[2019-01-17T01:40Z] gnomad_ac_popmax 3
[2019-01-17T01:40Z] gnomad_af -1.0
[2019-01-17T01:40Z] gnomad_af_afr 0.000860590022057
[2019-01-17T01:40Z] gnomad_af_amr 0.0
[2019-01-17T01:40Z] gnomad_af_asj 0.0
[2019-01-17T01:40Z] gnomad_af_eas 0.0
[2019-01-17T01:40Z] gnomad_af_fin 0.0
[2019-01-17T01:40Z] gnomad_af_nfe 0.000490200007334
[2019-01-17T01:40Z] gnomad_af_oth 0.0
[2019-01-17T01:40Z] gnomad_af_popmax 0.000860590022057
[2019-01-17T01:40Z] gnomad_af_sas -1.0
[2019-01-17T01:40Z] gnomad_afr_af
[2019-01-17T01:40Z] gnomad_amr_af
[2019-01-17T01:40Z] gnomad_an 12860
[2019-01-17T01:40Z] gnomad_an_amr 398
[2019-01-17T01:40Z] gnomad_an_asj 172
[2019-01-17T01:40Z] gnomad_an_eas 666
[2019-01-17T01:40Z] gnomad_an_fin 1632
[2019-01-17T01:40Z] gnomad_an_nfe 6120
[2019-01-17T01:40Z] gnomad_an_oth 386
[2019-01-17T01:40Z] gnomad_an_popmax 3486
[2019-01-17T01:40Z] gnomad_asj_af
[2019-01-17T01:40Z] gnomad_eas_af
[2019-01-17T01:40Z] gnomad_exomes_ac None
[2019-01-17T01:40Z] gnomad_exomes_af -1.0
[2019-01-17T01:40Z] gnomad_exomes_an None
[2019-01-17T01:40Z] gnomad_fin_af
[2019-01-17T01:40Z] gnomad_gc (6414, 6, 0)
[2019-01-17T01:40Z] gnomad_gc_female (2805, 2, 0)
[2019-01-17T01:40Z] gnomad_gc_male (3609, 4, 0)
[2019-01-17T01:40Z] gnomad_genomes_ac None
[2019-01-17T01:40Z] gnomad_genomes_af -1.0
[2019-01-17T01:40Z] gnomad_genomes_an None
[2019-01-17T01:40Z] gnomad_nfe_af
[2019-01-17T01:40Z] gnomad_oth_af
[2019-01-17T01:40Z] gnomad_sas_af
[2019-01-17T01:40Z] gt_alt_depths i\00\00\00
[2019-01-17T01:40Z] gt_alt_freqs d�؉�؉�?
[2019-01-17T01:40Z] gt_depths i
\00\00\00
[2019-01-17T01:40Z] gt_phases ?\00\00
[2019-01-17T01:40Z] gt_quals f\00\00\00@
[2019-01-17T01:40Z] gt_ref_depths i\00\00\00
[2019-01-17T01:40Z] gt_types i\00\00\00
[2019-01-17T01:40Z] gtex_v6p_gene None
[2019-01-17T01:40Z] gtex_v6p_tissue None
[2019-01-17T01:40Z] gts SC/C
[2019-01-17T01:40Z] h1_hesc_confidence_value None
[2019-01-17T01:40Z] h1_hesc_fitcons_score None
[2019-01-17T01:40Z] h1_hesc_fitcons_score_rankscore None
[2019-01-17T01:40Z] hg19_chr None
[2019-01-17T01:40Z] hg19_pos None
[2019-01-17T01:40Z] hgnc_id HGNC:37102
[2019-01-17T01:40Z] hgvs_offset
[2019-01-17T01:40Z] hgvsc
[2019-01-17T01:40Z] hgvsp
[2019-01-17T01:40Z] high_inf_pos
[2019-01-17T01:40Z] huvec_confidence_value None
[2019-01-17T01:40Z] huvec_fitcons_score None
[2019-01-17T01:40Z] huvec_fitcons_score_rankscore None
[2019-01-17T01:40Z] impact upstream_gene_variant
[2019-01-17T01:40Z] impact_severity LOW
[2019-01-17T01:40Z] impact_so upstream_gene_variant
[2019-01-17T01:40Z] integrated_confidence_value None
[2019-01-17T01:40Z] integrated_fitCons_score None
[2019-01-17T01:40Z] integrated_fitCons_score_rankscore None
[2019-01-17T01:40Z] integrated_fitcons_score None
[2019-01-17T01:40Z] integrated_fitcons_score_rankscore None
[2019-01-17T01:40Z] interpro_domain None
[2019-01-17T01:40Z] intron
[2019-01-17T01:40Z] is_canonical True
[2019-01-17T01:40Z] is_coding False
[2019-01-17T01:40Z] is_exonic False
[2019-01-17T01:40Z] is_lof False
[2019-01-17T01:40Z] is_splicing False
[2019-01-17T01:40Z] len None
[2019-01-17T01:40Z] lrt_converted_rankscore None
[2019-01-17T01:40Z] lrt_omega None
[2019-01-17T01:40Z] lrt_pred None
[2019-01-17T01:40Z] lrt_score None
[2019-01-17T01:40Z] m_cap_pred None
[2019-01-17T01:40Z] m_cap_rankscore None
[2019-01-17T01:40Z] m_cap_score None
[2019-01-17T01:40Z] max_aaf_all -1.0
[2019-01-17T01:40Z] max_af
[2019-01-17T01:40Z] max_af_pops
[2019-01-17T01:40Z] maxentscan_alt
[2019-01-17T01:40Z] maxentscan_diff
[2019-01-17T01:40Z] maxentscan_ref
[2019-01-17T01:40Z] metalr_pred None
[2019-01-17T01:40Z] metalr_rankscore None
[2019-01-17T01:40Z] metalr_score None
[2019-01-17T01:40Z] metasvm_pred None
[2019-01-17T01:40Z] metasvm_rankscore None
[2019-01-17T01:40Z] metasvm_score None
[2019-01-17T01:40Z] mleac 2
[2019-01-17T01:40Z] mleaf 1.0
[2019-01-17T01:40Z] motif_name
[2019-01-17T01:40Z] motif_pos
[2019-01-17T01:40Z] motif_score_change
[2019-01-17T01:40Z] mq 33.2099990845
[2019-01-17T01:40Z] mq0 0
[2019-01-17T01:40Z] mqranksum -1.22099995613
[2019-01-17T01:40Z] mutationassessor_pred None
[2019-01-17T01:40Z] mutationassessor_score None
[2019-01-17T01:40Z] mutationassessor_score_rankscore None
[2019-01-17T01:40Z] mutationassessor_uniprotid None
[2019-01-17T01:40Z] mutationassessor_variant None
[2019-01-17T01:40Z] mutationtaster_aae None
[2019-01-17T01:40Z] mutationtaster_converted_rankscore None
[2019-01-17T01:40Z] mutationtaster_model None
[2019-01-17T01:40Z] mutationtaster_pred None
[2019-01-17T01:40Z] mutationtaster_score None
[2019-01-17T01:40Z] mutpred_aachange None
[2019-01-17T01:40Z] mutpred_protid None
[2019-01-17T01:40Z] mutpred_rankscore None
[2019-01-17T01:40Z] mutpred_score None
[2019-01-17T01:40Z] mutpred_top5features None
[2019-01-17T01:40Z] negative_train_site False
[2019-01-17T01:40Z] num_exac_Het None
[2019-01-17T01:40Z] num_exac_Hom None
[2019-01-17T01:40Z] num_exac_het None
[2019-01-17T01:40Z] num_exac_hom None
[2019-01-17T01:40Z] num_het 0
[2019-01-17T01:40Z] num_hom_alt 1
[2019-01-17T01:40Z] num_hom_ref 0
[2019-01-17T01:40Z] num_unknown 0
[2019-01-17T01:40Z] old_multiallelic None
[2019-01-17T01:40Z] old_variant None
[2019-01-17T01:40Z] phastCons100way_vertebrate None
[2019-01-17T01:40Z] phastCons100way_vertebrate_rankscore None
[2019-01-17T01:40Z] phastCons20way_mammalian None
[2019-01-17T01:40Z] phastCons20way_mammalian_rankscore None
[2019-01-17T01:40Z] phastcons100way_vertebrate None
[2019-01-17T01:40Z] phastcons100way_vertebrate_rankscore None
[2019-01-17T01:40Z] phastcons20way_mammalian None
[2019-01-17T01:40Z] phastcons20way_mammalian_rankscore None
[2019-01-17T01:40Z] pheno
[2019-01-17T01:40Z] phyloP100way_vertebrate None
[2019-01-17T01:40Z] phyloP100way_vertebrate_rankscore None
[2019-01-17T01:40Z] phyloP20way_mammalian None
[2019-01-17T01:40Z] phyloP20way_mammalian_rankscore None
[2019-01-17T01:40Z] phylop100way_vertebrate None
[2019-01-17T01:40Z] phylop100way_vertebrate_rankscore None
[2019-01-17T01:40Z] phylop20way_mammalian None
[2019-01-17T01:40Z] phylop20way_mammalian_rankscore None
[2019-01-17T01:40Z] polyphen_pred
[2019-01-17T01:40Z] polyphen_score None
[2019-01-17T01:40Z] positive_train_site False
[2019-01-17T01:40Z] provean_converted_rankscore None
[2019-01-17T01:40Z] provean_pred None
[2019-01-17T01:40Z] provean_score None
[2019-01-17T01:40Z] pubmed
[2019-01-17T01:40Z] qd 1.67999994755
[2019-01-17T01:40Z] qual 21.8999996185
[2019-01-17T01:40Z] readposranksum 1.21099996567
[2019-01-17T01:40Z] ref CTAACCCTAACCT
[2019-01-17T01:40Z] refcodon None
[2019-01-17T01:40Z] refseq? None
[2019-01-17T01:40Z] refseq_functional_consequence None
[2019-01-17T01:40Z] refseq_gene None
[2019-01-17T01:40Z] refseq_id_c_change_p_change None
[2019-01-17T01:40Z] refseq_match
[2019-01-17T01:40Z] refseq_region None
[2019-01-17T01:40Z] reliability_index None
[2019-01-17T01:40Z] revel_rankscore None
[2019-01-17T01:40Z] revel_score None
[2019-01-17T01:40Z] rf_score None
[2019-01-17T01:40Z] rs_ids rs1367957502
[2019-01-17T01:40Z] sas_af
[2019-01-17T01:40Z] sift_pred
[2019-01-17T01:40Z] sift_score None
[2019-01-17T01:40Z] siphy_29way_logodds None
[2019-01-17T01:40Z] siphy_29way_logodds_rankscore None
[2019-01-17T01:40Z] siphy_29way_pi None
[2019-01-17T01:40Z] so upstream_gene_variant
[2019-01-17T01:40Z] somatic
[2019-01-17T01:40Z] sor 0.592999994755
[2019-01-17T01:40Z] source Ensembl
[2019-01-17T01:40Z] spliceregion
[2019-01-17T01:40Z] start 10167
[2019-01-17T01:40Z] strand 1
[2019-01-17T01:40Z] sub_type del
[2019-01-17T01:40Z] swissprot
[2019-01-17T01:40Z] symbol_source HGNC
[2019-01-17T01:40Z] top_consequence upstream_gene_variant
[2019-01-17T01:40Z] transcript ENST00000456328
[2019-01-17T01:40Z] transcript_id_vest3 None
[2019-01-17T01:40Z] transcript_var_vest3 None
[2019-01-17T01:40Z] trembl
[2019-01-17T01:40Z] tsl 1
[2019-01-17T01:40Z] type indel
[2019-01-17T01:40Z] uniparc
[2019-01-17T01:40Z] used_ref TAACCCTAACCT
[2019-01-17T01:40Z] variant_class deletion
[2019-01-17T01:40Z] variant_id 2
[2019-01-17T01:40Z] vcf_id rs1367957502
[2019-01-17T01:40Z] vest3_rankscore None
[2019-01-17T01:40Z] vest3_score None
[2019-01-17T01:40Z] vqslod 3.88000011444
[2019-01-17T01:40Z] Traceback (most recent call last):
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 924, in <module>
[2019-01-17T01:40Z]     impacts_extras=a.impacts_field, aok=a.a_ok)
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 234, in __init__
[2019-01-17T01:40Z]     self.load()
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 319, in load
[2019-01-17T01:40Z]     i = self._load(self.cache, create=True, start=1)
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 312, in _load
[2019-01-17T01:40Z]     self.insert(variants, expanded, keys, i, create=create)
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 374, in insert
[2019-01-17T01:40Z]     vilengths, variant_impacts)
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 402, in _insert
[2019-01-17T01:40Z]     self.__insert(v_objs, self.metadata.tables['variants'].insert())
[2019-01-17T01:40Z]   File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 436, in __insert
[2019-01-17T01:40Z]     raise e
[2019-01-17T01:40Z] sqlalchemy.exc.InterfaceError: (sqlite3.InterfaceError) Error binding parameter 215 - probably unsupported type. [SQL: u'INSERT INTO variants (variant_id, chrom, start, "end", vcf_id, ref, alt, qual, filter, type, sub_type, call_rate, num_hom_ref, num_het, num_hom_alt, num_unknown, aaf, gene, ensembl_gene_id, transcript, is_exonic, is_coding, is_lof, is_splicing, is_canonical, exon, codon_change, aa_change, aa_length, biotype, impact, impact_so, impact_severity, polyphen_pred, polyphen_score, sift_pred, sift_score, ac, af, an, altaineandertal, ancestral_allele, baseqranksum, cadd_phred, cadd_raw, cadd_raw_rankscore, clippingranksum, dann_rankscore, dann_score, db, decomposed, dp, ds, denisova, eigen_pc_phred, eigen_pc_raw, eigen_pc_raw_rankscore, eigen_phred, eigen_raw, eigen_coding_or_noncoding, "ensembl?", ensembl_functional_consequence, ensembl_gene, ensembl_geneid, ensembl_id_c_change_p_change, ensembl_proteinid, ensembl_region, ensembl_transcriptid, excesshet, fathmm_converted_rankscore, fathmm_pred, fathmm_score, fs, "gerp++_nr", "gerp++_rs", "gerp++_rs_rankscore", gm12878_confidence_value, gm12878_fitcons_score, gm12878_fitcons_score_rankscore, gtex_v6p_gene, gtex_v6p_tissue, genocanyon_score, genocanyon_score_rankscore, h1_hesc_confidence_value, h1_hesc_fitcons_score, h1_hesc_fitcons_score_rankscore, huvec_confidence_value, huvec_fitcons_score, huvec_fitcons_score_rankscore, interpro_domain, len, lrt_omega, lrt_converted_rankscore, lrt_pred, lrt_score, m_cap_pred, m_cap_rankscore, m_cap_score, mleac, mleaf, mq, mq0, mqranksum, metalr_pred, metalr_rankscore, metalr_score, metasvm_pred, metasvm_rankscore, metasvm_score, mutpred_aachange, mutpred_top5features, mutpred_protid, mutpred_rankscore, mutpred_score, mutationassessor_uniprotid, mutationassessor_pred, mutationassessor_score, mutationassessor_score_rankscore, mutationassessor_variant, mutationtaster_aae, mutationtaster_converted_rankscore, mutationtaster_model, mutationtaster_pred, mutationtaster_score, negative_train_site, old_multiallelic, old_variant, positive_train_site, provean_converted_rankscore, provean_pred, provean_score, qd, revel_rankscore, revel_score, readposranksum, "refseq?", refseq_functional_consequence, refseq_gene, refseq_id_c_change_p_change, refseq_region, reliability_index, sor, siphy_29way_logodds, siphy_29way_logodds_rankscore, siphy_29way_pi, transcript_id_vest3, transcript_var_vest3, vest3_rankscore, vest3_score, vqslod, ac_adj_exac_afr, ac_adj_exac_amr, ac_adj_exac_eas, ac_adj_exac_fin, ac_adj_exac_nfe, ac_adj_exac_oth, ac_adj_exac_sas, ac_exac_all, ada_score, af_adj_exac_afr, af_adj_exac_amr, af_adj_exac_eas, af_adj_exac_fin, af_adj_exac_nfe, af_adj_exac_oth, af_adj_exac_sas, af_esp_aa, af_esp_all, af_esp_ea, af_exac_all, an_adj_exac_afr, an_adj_exac_amr, an_adj_exac_eas, an_adj_exac_fin, an_adj_exac_nfe, an_adj_exac_oth, an_adj_exac_sas, an_exac_all, cds_strand, clinvar_disease_name, clinvar_sig, codon_degeneracy, codonpos, common_pathogenic, culprit, fathmm_mkl_coding_group, fathmm_mkl_coding_pred, fathmm_mkl_coding_rankscore, fathmm_mkl_coding_score, gnomad_ac, gnomad_ac_amr, gnomad_ac_asj, gnomad_ac_eas, gnomad_ac_fin, gnomad_ac_nfe, gnomad_ac_oth, gnomad_ac_popmax, gnomad_af, gnomad_af_afr, gnomad_af_amr, gnomad_af_asj, gnomad_af_eas, gnomad_af_fin, gnomad_af_nfe, gnomad_af_oth, gnomad_af_popmax, gnomad_af_sas, gnomad_an, gnomad_an_amr, gnomad_an_asj, gnomad_an_eas, gnomad_an_fin, gnomad_an_nfe, gnomad_an_oth, gnomad_an_popmax, gnomad_gc, gnomad_gc_female, gnomad_gc_male, gnomad_exomes_ac, gnomad_exomes_af, gnomad_exomes_an, gnomad_genomes_ac, gnomad_genomes_af, gnomad_genomes_an, hg19_chr, hg19_pos, integrated_confidence_value, integrated_fitcons_score, integrated_fitcons_score_rankscore, max_aaf_all, num_exac_het, num_exac_hom, phastcons100way_vertebrate, phastcons100way_vertebrate_rankscore, phastcons20way_mammalian, phastcons20way_mammalian_rankscore, phylop100way_vertebrate, phylop100way_vertebrate_rankscore, phylop20way_mammalian, phylop20way_mammalian_rankscore, refcodon, rf_score, rs_ids, allele, feature_type, intron, hgvsc, hgvsp, cdna_position, cds_position, existing_variation, allele_num, distance, strand, flags, variant_class, symbol_source, hgnc_id, tsl, appris, ccds, ensp, swissprot, trembl, uniparc, refseq_match, source, given_ref, used_ref, bam_edit, gene_pheno, domains, hgvs_offset, afr_af, amr_af, eas_af, eur_af, sas_af, aa_af, ea_af, gnomad_afr_af, gnomad_amr_af, gnomad_asj_af, gnomad_eas_af, gnomad_fin_af, gnomad_nfe_af, gnomad_oth_af, gnomad_sas_af, max_af, max_af_pops, clin_sig, somatic, pheno, pubmed, motif_name, motif_pos, high_inf_pos, motif_score_change, maxentscan_alt, maxentscan_diff, maxentscan_ref, spliceregion, gts, gt_types, gt_phases, gt_depths, gt_ref_depths, gt_alt_depths, gt_quals, gt_alt_freqs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'] [parameters: (2, u'chr1', 10167, 10180, u'rs1367957502', u'CTAACCCTAACCT', u'C', 21.899999618530273, None, 'indel', 'del', 1.0, 0, 0, 1, 0, 1.0, u'DDX11L1', None, u'ENST00000456328', 0, 0, 0, 0, 1, '', '', '', u'', u'processed_transcript', u'upstream_gene_variant', u'upstream_gene_variant', 'LOW', u'', None, u'', None, 2, u'', 2, None, None, -1.1030000448226929, None, None, None, 0.0, None, None, 0, 0, 18, 0, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 3.0102999210357666, None, None, None, 0.0, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 2, 1.0, 33.209999084472656, 0, -1.2209999561309814, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 0, None, 'None', 0, None, None, None, 1.6799999475479126, None, None, 1.2109999656677246, None, None, None, None, None, None, 0.5929999947547913, None, None, None, None, None, None, None, 3.880000114440918, None, None, None, None, None, None, None, None, None, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, None, None, None, None, None, 0, u'QD', None, None, None, None, 6, 0, 0, 0, 0, 3, 0, 3, -1.0, 0.0008605900220572948, 0.0, 0.0, 0.0, 0.0, 0.0004902000073343515, 0.0, 0.0008605900220572948, -1.0, 12860, 398, 172, 666, 1632, 6120, 386, 3486, (6414, 6, 0), (2805, 2, 0), (3609, 4, 0), None, -1.0, None, None, -1.0, None, None, None, None, None, None, -1.0, None, None, None, None, None, None, None, None, None, None, None, None, u'rs1367957502', u'-', u'Transcript', u'', u'', u'', u'', u'', u'rs1367957502', u'1', u'1689', u'1', u'', u'deletion', u'HGNC', u'HGNC:37102', u'1', u'', u'', u'', u'', u'', u'', u'', u'Ensembl', u'TAACCCTAACCT', u'TAACCCTAACCT', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', <read-only buffer for 0x7fc6079d2e40, size -1, offset 0 at 0x7fc5af5b2530>, <read-only buffer for 0x7fc6079d2e10, size -1, offset 0 at 0x7fc5af5b2570>, <read-only buffer for 0x7fc6079d2e70, size -1, offset 0 at 0x7fc5af5b25b0>, <read-only buffer for 0x7fc6079d2ea0, size -1, offset 0 at 0x7fc5af5b25f0>, <read-only buffer for 0x7fc6079d2ed0, size -1, offset 0 at 0x7fc5af5b2630>, <read-only buffer for 0x7fc6079d2f00, size -1, offset 0 at 0x7fc5af5b2670>, <read-only buffer for 0x7fc6079d2f30, size -1, offset 0 at 0x7fc5af5b26b0>, <read-only buffer for 0x7fc6079d2f60, size -1, offset 0 at 0x7fc5af5b26f0>)] (Background on this error at: http://sqlalche.me/e/rvf5)
[2019-01-17T01:40Z] Uncaught exception occurred
Traceback (most recent call last):
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/bcbio/provenance/do.py", line 26, in run
    _do_run(cmd, checks, log_stdout, env=env)
  File "/usr/local/share/bcbio/anaconda/lib/python2.7/site-packages/bcbio/provenance/do.py", line 106, in _do_run
    raise subprocess.CalledProcessError(exitcode, error_msg)
CalledProcessError: Command '/usr/local/share/bcbio/anaconda/bin/vcf2db.py /home/paulosilva/GenomasMiguel/WGSRun/WGSRun/work/gemini/Uni20128-gatk-haplotype-nomultiallelic-annotated-dbnsfp.vcf.gz /home/paulosilva/GenomasMiguel/WGSRun/WGSRun/work/gemini/Uni20128-gatk-haplotype-nomultiallelic.ped /home/paulosilva/GenomasMiguel/WGSRun/WGSRun/work/bcbiotx/tmpkcTljW/Uni20128-gatk-haplotype.db --expand gt_types --expand gt_ref_depths --expand gt_alt_depths
mutpred_score None
mutpred_top5features None
negative_train_site False
num_exac_Het None
num_exac_Hom None
num_exac_het None
num_exac_hom None
num_het 0
num_hom_alt 1
num_hom_ref 0
num_unknown 0
old_multiallelic None
old_variant None
phastCons100way_vertebrate None
phastCons100way_vertebrate_rankscore None
phastCons20way_mammalian None
phastCons20way_mammalian_rankscore None
phastcons100way_vertebrate None
phastcons100way_vertebrate_rankscore None
phastcons20way_mammalian None
phastcons20way_mammalian_rankscore None
pheno 
phyloP100way_vertebrate None
phyloP100way_vertebrate_rankscore None
phyloP20way_mammalian None
phyloP20way_mammalian_rankscore None
phylop100way_vertebrate None
phylop100way_vertebrate_rankscore None
phylop20way_mammalian None
phylop20way_mammalian_rankscore None
polyphen_pred 
polyphen_score None
positive_train_site False
provean_converted_rankscore None
provean_pred None
provean_score None
pubmed 
qd 1.67999994755
qual 21.8999996185
readposranksum 1.21099996567
ref CTAACCCTAACCT
refcodon None
refseq? None
refseq_functional_consequence None
refseq_gene None
refseq_id_c_change_p_change None
refseq_match 
refseq_region None
reliability_index None
revel_rankscore None
revel_score None
rf_score None
rs_ids rs1367957502
sas_af 
sift_pred 
sift_score None
siphy_29way_logodds None
siphy_29way_logodds_rankscore None
siphy_29way_pi None
so upstream_gene_variant
somatic 
sor 0.592999994755
source Ensembl
spliceregion 
start 10167
strand 1
sub_type del
swissprot 
symbol_source HGNC
top_consequence upstream_gene_variant
transcript ENST00000456328
transcript_id_vest3 None
transcript_var_vest3 None
trembl 
tsl 1
type indel
uniparc 
used_ref TAACCCTAACCT
variant_class deletion
variant_id 2
vcf_id rs1367957502
vest3_rankscore None
vest3_score None
vqslod 3.88000011444
Traceback (most recent call last):
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 924, in <module>
    impacts_extras=a.impacts_field, aok=a.a_ok)
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 234, in __init__
    self.load()
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 319, in load
    i = self._load(self.cache, create=True, start=1)
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 312, in _load
    self.insert(variants, expanded, keys, i, create=create)
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 374, in insert
    vilengths, variant_impacts)
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 402, in _insert
    self.__insert(v_objs, self.metadata.tables['variants'].insert())
  File "/usr/local/share/bcbio/anaconda/bin/vcf2db.py", line 436, in __insert
    raise e
sqlalchemy.exc.InterfaceError: (sqlite3.InterfaceError) Error binding parameter 215 - probably unsupported type. [SQL: u'INSERT INTO variants (variant_id, chrom, start, "end", vcf_id, ref, alt, qual, filter, type, sub_type, call_rate, num_hom_ref, num_het, num_hom_alt, num_unknown, aaf, gene, ensembl_gene_id, transcript, is_exonic, is_coding, is_lof, is_splicing, is_canonical, exon, codon_change, aa_change, aa_length, biotype, impact, impact_so, impact_severity, polyphen_pred, polyphen_score, sift_pred, sift_score, ac, af, an, altaineandertal, ancestral_allele, baseqranksum, cadd_phred, cadd_raw, cadd_raw_rankscore, clippingranksum, dann_rankscore, dann_score, db, decomposed, dp, ds, denisova, eigen_pc_phred, eigen_pc_raw, eigen_pc_raw_rankscore, eigen_phred, eigen_raw, eigen_coding_or_noncoding, "ensembl?", ensembl_functional_consequence, ensembl_gene, ensembl_geneid, ensembl_id_c_change_p_change, ensembl_proteinid, ensembl_region, ensembl_transcriptid, excesshet, fathmm_converted_rankscore, fathmm_pred, fathmm_score, fs, "gerp++_nr", "gerp++_rs", "gerp++_rs_rankscore", gm12878_confidence_value, gm12878_fitcons_score, gm12878_fitcons_score_rankscore, gtex_v6p_gene, gtex_v6p_tissue, genocanyon_score, genocanyon_score_rankscore, h1_hesc_confidence_value, h1_hesc_fitcons_score, h1_hesc_fitcons_score_rankscore, huvec_confidence_value, huvec_fitcons_score, huvec_fitcons_score_rankscore, interpro_domain, len, lrt_omega, lrt_converted_rankscore, lrt_pred, lrt_score, m_cap_pred, m_cap_rankscore, m_cap_score, mleac, mleaf, mq, mq0, mqranksum, metalr_pred, metalr_rankscore, metalr_score, metasvm_pred, metasvm_rankscore, metasvm_score, mutpred_aachange, mutpred_top5features, mutpred_protid, mutpred_rankscore, mutpred_score, mutationassessor_uniprotid, mutationassessor_pred, mutationassessor_score, mutationassessor_score_rankscore, mutationassessor_variant, mutationtaster_aae, mutationtaster_converted_rankscore, mutationtaster_model, mutationtaster_pred, mutationtaster_score, negative_train_site, old_multiallelic, old_variant, positive_train_site, provean_converted_rankscore, provean_pred, provean_score, qd, revel_rankscore, revel_score, readposranksum, "refseq?", refseq_functional_consequence, refseq_gene, refseq_id_c_change_p_change, refseq_region, reliability_index, sor, siphy_29way_logodds, siphy_29way_logodds_rankscore, siphy_29way_pi, transcript_id_vest3, transcript_var_vest3, vest3_rankscore, vest3_score, vqslod, ac_adj_exac_afr, ac_adj_exac_amr, ac_adj_exac_eas, ac_adj_exac_fin, ac_adj_exac_nfe, ac_adj_exac_oth, ac_adj_exac_sas, ac_exac_all, ada_score, af_adj_exac_afr, af_adj_exac_amr, af_adj_exac_eas, af_adj_exac_fin, af_adj_exac_nfe, af_adj_exac_oth, af_adj_exac_sas, af_esp_aa, af_esp_all, af_esp_ea, af_exac_all, an_adj_exac_afr, an_adj_exac_amr, an_adj_exac_eas, an_adj_exac_fin, an_adj_exac_nfe, an_adj_exac_oth, an_adj_exac_sas, an_exac_all, cds_strand, clinvar_disease_name, clinvar_sig, codon_degeneracy, codonpos, common_pathogenic, culprit, fathmm_mkl_coding_group, fathmm_mkl_coding_pred, fathmm_mkl_coding_rankscore, fathmm_mkl_coding_score, gnomad_ac, gnomad_ac_amr, gnomad_ac_asj, gnomad_ac_eas, gnomad_ac_fin, gnomad_ac_nfe, gnomad_ac_oth, gnomad_ac_popmax, gnomad_af, gnomad_af_afr, gnomad_af_amr, gnomad_af_asj, gnomad_af_eas, gnomad_af_fin, gnomad_af_nfe, gnomad_af_oth, gnomad_af_popmax, gnomad_af_sas, gnomad_an, gnomad_an_amr, gnomad_an_asj, gnomad_an_eas, gnomad_an_fin, gnomad_an_nfe, gnomad_an_oth, gnomad_an_popmax, gnomad_gc, gnomad_gc_female, gnomad_gc_male, gnomad_exomes_ac, gnomad_exomes_af, gnomad_exomes_an, gnomad_genomes_ac, gnomad_genomes_af, gnomad_genomes_an, hg19_chr, hg19_pos, integrated_confidence_value, integrated_fitcons_score, integrated_fitcons_score_rankscore, max_aaf_all, num_exac_het, num_exac_hom, phastcons100way_vertebrate, phastcons100way_vertebrate_rankscore, phastcons20way_mammalian, phastcons20way_mammalian_rankscore, phylop100way_vertebrate, phylop100way_vertebrate_rankscore, phylop20way_mammalian, phylop20way_mammalian_rankscore, refcodon, rf_score, rs_ids, allele, feature_type, intron, hgvsc, hgvsp, cdna_position, cds_position, existing_variation, allele_num, distance, strand, flags, variant_class, symbol_source, hgnc_id, tsl, appris, ccds, ensp, swissprot, trembl, uniparc, refseq_match, source, given_ref, used_ref, bam_edit, gene_pheno, domains, hgvs_offset, afr_af, amr_af, eas_af, eur_af, sas_af, aa_af, ea_af, gnomad_afr_af, gnomad_amr_af, gnomad_asj_af, gnomad_eas_af, gnomad_fin_af, gnomad_nfe_af, gnomad_oth_af, gnomad_sas_af, max_af, max_af_pops, clin_sig, somatic, pheno, pubmed, motif_name, motif_pos, high_inf_pos, motif_score_change, maxentscan_alt, maxentscan_diff, maxentscan_ref, spliceregion, gts, gt_types, gt_phases, gt_depths, gt_ref_depths, gt_alt_depths, gt_quals, gt_alt_freqs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'] [parameters: (2, u'chr1', 10167, 10180, u'rs1367957502', u'CTAACCCTAACCT', u'C', 21.899999618530273, None, 'indel', 'del', 1.0, 0, 0, 1, 0, 1.0, u'DDX11L1', None, u'ENST00000456328', 0, 0, 0, 0, 1, '', '', '', u'', u'processed_transcript', u'upstream_gene_variant', u'upstream_gene_variant', 'LOW', u'', None, u'', None, 2, u'', 2, None, None, -1.1030000448226929, None, None, None, 0.0, None, None, 0, 0, 18, 0, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 3.0102999210357666, None, None, None, 0.0, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 2, 1.0, 33.209999084472656, 0, -1.2209999561309814, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 0, None, 'None', 0, None, None, None, 1.6799999475479126, None, None, 1.2109999656677246, None, None, None, None, None, None, 0.5929999947547913, None, None, None, None, None, None, None, 3.880000114440918, None, None, None, None, None, None, None, None, None, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, None, None, None, None, None, 0, u'QD', None, None, None, None, 6, 0, 0, 0, 0, 3, 0, 3, -1.0, 0.0008605900220572948, 0.0, 0.0, 0.0, 0.0, 0.0004902000073343515, 0.0, 0.0008605900220572948, -1.0, 12860, 398, 172, 666, 1632, 6120, 386, 3486, (6414, 6, 0), (2805, 2, 0), (3609, 4, 0), None, -1.0, None, None, -1.0, None, None, None, None, None, None, -1.0, None, None, None, None, None, None, None, None, None, None, None, None, u'rs1367957502', u'-', u'Transcript', u'', u'', u'', u'', u'', u'rs1367957502', u'1', u'1689', u'1', u'', u'deletion', u'HGNC', u'HGNC:37102', u'1', u'', u'', u'', u'', u'', u'', u'', u'Ensembl', u'TAACCCTAACCT', u'TAACCCTAACCT', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', <read-only buffer for 0x7fc6079d2e40, size -1, offset 0 at 0x7fc5af5b2530>, <read-only buffer for 0x7fc6079d2e10, size -1, offset 0 at 0x7fc5af5b2570>, <read-only buffer for 0x7fc6079d2e70, size -1, offset 0 at 0x7fc5af5b25b0>, <read-only buffer for 0x7fc6079d2ea0, size -1, offset 0 at 0x7fc5af5b25f0>, <read-only buffer for 0x7fc6079d2ed0, size -1, offset 0 at 0x7fc5af5b2630>, <read-only buffer for 0x7fc6079d2f00, size -1, offset 0 at 0x7fc5af5b2670>, <read-only buffer for 0x7fc6079d2f30, size -1, offset 0 at 0x7fc5af5b26b0>, <read-only buffer for 0x7fc6079d2f60, size -1, offset 0 at 0x7fc5af5b26f0>)] (Background on this error at: http://sqlalche.me/e/rvf5)
```
After dissecting this log and examining some records in `gnomad_genome.vcf.gz`, this seems to happen because, in gnomad VCFs, the fields `GC`, `GC_Male`, `GC_Female` (genotype counts) can have more than one value. For position chr1:10168, where it failed failed in the log above:
```
tabix gnomad_genome.vcf.gz chr1:10168-10168

chr1	10168	.	CTAACCCTAACCT	C	6942.66	LCR;SEGDUP	AC=6;AF=0.000466563;AN=12860;AC_AFR=3;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=3;AC_OTH=0;AC_Male=4;AC_Female=2;AN_AFR=3486;AN_AMR=398;AN_ASJ=172;AN_EAS=666;AN_FIN=1632;AN_NFE=6120;AN_OTH=386;AN_Male=7238;AN_Female=5622;AF_AFR=0.000860585;AF_AMR=0;AF_ASJ=0;AF_EAS=0;AF_FIN=0;AF_NFE=0.000490196;AF_OTH=0;AF_Male=0.000552639;AF_Female=0.000355745;GC_AFR=1738,3,0;GC_AMR=198,0,0;GC_ASJ=86,0,0;GC_EAS=331,0,0;GC_FIN=814,0,0;GC_NFE=3055,3,0;GC_OTH=192,0,0;GC_Male=3609,4,0;GC_Female=2805,2,0;AC_raw=9;AN_raw=28000;AF_raw=0.000321429;GC_raw=13968,9,0;GC=6414,6,0;AC_POPMAX=3;AN_POPMAX=3486;AF_POPMAX=0.000860585
```

Changing `vcfanno` conf files for the above fields from `self` to `sum` (I used `sum` instead of `first` to get total the genotype counts) fixes this error and proceeds with `gemini` DB creation. 

This issue is quite similar to issue #2567, but is happening using `bcbio-nextgen`-provided default configuration files. After this PR is merged, `vcfanno` ggd-recipes also need to be updated in `cloudbiolinux`.

Thank you!
-- Paulo