### PR TITLE
Fix HISAT2 firststrand strandedness for single-end samples

### DIFF
--- a/bcbio/ngsalign/bowtie2.py
+++ b/bcbio/ngsalign/bowtie2.py
@@ -88,7 +88,7 @@ def filter_multimappers(align_file, data):
     bed_cmd = '-L {0}'.format(bed_file) if bed_file else " "
     if utils.file_exists(out_file):
         return out_file
-    base_filter = '-F "[XS] == null and not unmapped {paired_filter} and not duplicate" '
+    base_filter = '-F "not unmapped {paired_filter} and not duplicate" '
     if bam.is_paired(align_file):
         paired_filter = "and paired and proper_pair"
     else:

--- a/bcbio/ngsalign/bowtie2.py
+++ b/bcbio/ngsalign/bowtie2.py
@@ -88,7 +88,7 @@ def filter_multimappers(align_file, data):
     bed_cmd = '-L {0}'.format(bed_file) if bed_file else " "
     if utils.file_exists(out_file):
         return out_file
-    base_filter = '-F "not unmapped {paired_filter} and not duplicate" '
+    base_filter = '-F "[XS] == null and not unmapped {paired_filter} and not duplicate" '
     if bam.is_paired(align_file):
         paired_filter = "and paired and proper_pair"
     else:

--- a/bcbio/ngsalign/hisat2.py
+++ b/bcbio/ngsalign/hisat2.py
@@ -102,7 +102,7 @@ def _get_stranded_flag(data, paired):
         else:
             return ""
     else:
-        if strandedness == "firstrand":
+        if strandedness == "firststrand":
             return base + "R"
         elif strandedness == "secondstrand":
             return base + "F"


### PR DESCRIPTION
`hisat2.py`: The if/else statement to handle the `strandedness` argument for stranded single-end samples had a typo that results in the pipeline always running as `secondstrand`, even when the user requests `firststrand`.