### PR TITLE
MultiQC: faster path lookups 

### DIFF
--- a/bcbio/qc/multiqc.py
+++ b/bcbio/qc/multiqc.py
@@ -213,6 +213,7 @@ def _work_path_to_rel_final_path(path, upload_path_mapping, upload_base_dir):
                 if os.path.isdir(work_path):
                     final_path = upload_path_mapping[work_path]
                     upload_path = path.replace(work_path, final_path)
+                    break
 
     if upload_path is not None:
         return os.path.relpath(upload_path, upload_base_dir)


### PR DESCRIPTION
The work `_work_path_to_rel_final_path` does is wasteful, because it
does up to thousands of `isfile` and `isdir` calls for every path
tested.

This might make sense if the files to check are small, but not with very
large analyses.

This patch changes the behavior to take into account the fact that we're
dealing with a dictionary:

1. If the path matches the dictionary keys, fetch it immediately (O(1))
2. If the path is a file, then we have our path
3. If it is not in dictionary, it is part of a directory: select, among
   the keys, *only* those that contain it
4. Of these, check if they are directories and break if a match is found

This should make the function significantly faster because it will
reduce the number of actual filesystem lookups to almost nothing.

@chapmanb  @roryk  - Please check if this still matches your expectations of what the code should do