### PR TITLE
Eliminated warning for Sphinx Doc generation

### DIFF
--- a/docs/contents/installation.rst
+++ b/docs/contents/installation.rst
@@ -283,7 +283,7 @@ use ``https://`` globally instead of ``git://``::
     $ git config --global url.https://github.com/.insteadOf git://github.com/
 
 GATK or Java Errors
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 Most software tools used by bcbio require Java 1.8. bcbio distributes an OpenJDK
 Java build and uses it so you don't need to install anything. Older versions of
 GATK (< 3.6) and MuTect require a locally installed Java 1.7. If you


### PR DESCRIPTION
Sorry for that piece of irrelevance.

You referenced CloudBioLinux. I would (obviously) very much like like to bring the Debian package to a stage that it would qualify to be accepted here. At what stage would you consider adding such a reference?

Best,
Steffen