### PR TITLE
Fixing indication of regular expressions

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -240,7 +240,7 @@ class BroadRunner:
         cl += ["--version"]
         p = subprocess.Popen(cl, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         # fix for issue #494
-        pat = re.compile('([\d|\.]*)(\(\d*\)$)')  # matches '1.96(1510)'
+        pat = re.compile(r'([\d|\.]*)(\(\d*\)$)')  # matches '1.96(1510)'
         m = pat.search(p.stdout.read())
         version = m.group(1)
         self._picard_version = version

--- a/bcbio/structural/cn_mops.py
+++ b/bcbio/structural/cn_mops.py
@@ -72,7 +72,7 @@ def _prep_sample_cnvs(cnv_file, data):
     import pybedtools
     sample_name = tz.get_in(["rgnames", "sample"], data)
     def make_names(name):
-        return re.sub("[^\w.]", '.', name)
+        return re.sub(r"[^\w.]", '.', name)
     def matches_sample_name(feat):
         return (feat.name == sample_name or feat.name == "X%s" % sample_name or
                 feat.name == make_names(sample_name))

--- a/bcbio/structural/delly.py
+++ b/bcbio/structural/delly.py
@@ -77,7 +77,7 @@ def _bgzip_and_clean(bcf_file, items):
             if not utils.file_exists(bcf_file):
                 vcfutils.write_empty_vcf(tx_out_file, samples=[dd.get_sample_name(d) for d in items])
             else:
-                cmd = ("bcftools view {bcf_file} | sed 's/\.,\.,\././' | bgzip -c > {tx_out_file}")
+                cmd = ("bcftools view {bcf_file} | sed 's/\\.,\\.,\\././' | bgzip -c > {tx_out_file}")
                 do.run(cmd.format(**locals()), "Convert and clean delly output")
     return vcfutils.bgzip_and_index(out_file, items[0]["config"])
 


### PR DESCRIPTION
Avoids deprecation warnings. When running python with -W all, like when running autotests of the bcbio Debian package, one can otherwise observe the following:
```
bcbio/broad/__init__.py:246
  /bcbio/.pybuild/cpython3_3.7_bcbio/build/bcbio/broad/__init__.py:246: DeprecationWarning: invalid escape sequence \d
    pat = re.compile('([\d|\.]*)(\(\d*\)$)')  # matches '1.96(1510)'
bcbio/structural/cn_mops.py:75
  /bcbio/.pybuild/cpython3_3.7_bcbio/build/bcbio/structural/cn_mops.py:75: DeprecationWarning: invalid escape sequence \w
    return re.sub("[^\w.]", '.', name)
bcbio/structural/delly.py:82
  /bcbio/.pybuild/cpython3_3.7_bcbio/build/bcbio/structural/delly.py:82: DeprecationWarning: invalid escape sequence \.
    cmd = ("bcftools view {bcf_file} | sed 's/\.,\.,\././' | bgzip -c > {tx_out_file}")
```
