### PR TITLE
Series of spelling errors in documentation.

### DIFF
--- a/bcbio/rnaseq/ericscript.py
+++ b/bcbio/rnaseq/ericscript.py
@@ -76,7 +76,7 @@ class EricScriptConfig(object):
 
     Private constants:
         _OUTPUT_DIR_NAME: name of the dir created in working directory for
-    ericscript ouput
+    ericscript output
     """
     info_message = 'Detect gene fusions with EricScript'
     EXECUTABLE = 'ericscript.pl'

--- a/docs/contents/cloud.rst
+++ b/docs/contents/cloud.rst
@@ -271,7 +271,7 @@ run ``bcbio_vm.py graph bcbio-nextgen.log --cluster local`` instead.
 
 For convenience, there's a "serialize" flag ('-s') that saves the dataframe used
 for plotting. In order to explore the data and extract specific datapoints
-or zoom, one could just deserialize the ouput like a python pickle file:
+or zoom, one could just deserialize the output like a python pickle file:
 
 ```
     import cPickle as pickle

--- a/docs/contents/configuration.rst
+++ b/docs/contents/configuration.rst
@@ -899,7 +899,7 @@ ChIP sequencing
 - ``peakcaller`` bcbio only accepts ``[macs2]``
 - ``aligner`` Currently ``bowtie2`` is the only one tested
 - The ``phenotype`` and ``batch`` tags need to be set under ``metadata`` in the config YAML file. The ``phenotype`` tag will specify the chip (``phenotype: chip``) and input samples (``phenotype: input``). The ``batch`` tag will specify the input-chip pairs of samples for example, ``batch: pair1``. Same input can be used for different chip samples giving a list of distinct values: ``batch: [sample1, sample2]``.
-- ``chip_method``: currently supporting standard CHIP-seq (TF or broad regions using `chip`) or ATAC-seq (`atac`). Paramters will change depending on the option to get the best possible results. Only macs2 supported for now.
+- ``chip_method``: currently supporting standard CHIP-seq (TF or broad regions using `chip`) or ATAC-seq (`atac`). Parameters will change depending on the option to get the best possible results. Only macs2 supported for now.
 
 You can pass different parameters for ``macs2`` adding to :ref:`config-resources`::
 

--- a/docs/contents/installation.rst
+++ b/docs/contents/installation.rst
@@ -207,7 +207,7 @@ GATK and MuTect/MuTect2
 bcbio includes an installation of GATK4, which is freely available for all uses.
 This is the default runner for HaplotypeCaller or MuTect2. If you want to use an
 older version of GATK, it requires manual installation. This is freely available
-for academic users, but requires a `license for commerical use
+for academic users, but requires a `license for commercial use
 <https://www.broadinstitute.org/gatk/about/#licensing>`_. It is not freely
 redistributable so requires a manual download from the `GATK download`_ site.
 You also need to include ``tools_off: [gatk4]`` in your configuration for runs:
@@ -231,7 +231,7 @@ the GATK distribution. Then make this jar available to bcbio-nextgen with::
 This will copy the jar and update your bcbio_system.yaml and manifest files to
 reflect the new version.
 
-MuTect also has similar licensing terms and requires a license for commerical
+MuTect also has similar licensing terms and requires a license for commercial
 use. After `downloading the MuTect jar
 <https://www.broadinstitute.org/gatk/download/>`_, make it available to bcbio::
 

--- a/docs/contents/parallel.rst
+++ b/docs/contents/parallel.rst
@@ -206,7 +206,7 @@ underlying issue.
 No parallelization where expected
 =================================
 
-This may occure if the current execution is a re-run of a previous project:
+This may occur if the current execution is a re-run of a previous project:
 
 - Files in ``checkpoints_parallel/*.done`` tell bcbio not to parallelize already
   executed pipeline tasks. This makes restarts faster by avoiding re-starting a

--- a/docs/contents/presentations.rst
+++ b/docs/contents/presentations.rst
@@ -25,7 +25,7 @@ Presentations
   <https://github.com/chapmanb/bcbb/blob/master/talks/ngscourse2017_teaching/ngscourse2017_teaching.pdf>`_
 
 - Training course for the `Cancer Genomics Cloud
-  <http://www.cancergenomicscloud.org/>`_, decribing how bcbio uses the Common
+  <http://www.cancergenomicscloud.org/>`_, describing how bcbio uses the Common
   Workflow Language to run in multiple infrastructures (1 May 2017): `slides
   <https://github.com/chapmanb/bcbb/blob/master/talks/cgc2017_bcbio_cwl/cgc2017_bcbiocwl.pdf>`_
 


### PR DESCRIPTION
@mr-c  once upon a time fixed these for the Debian package. And then these have apparently
been forgotten about.  That is the problem with 24h days.
There are ways that are past my routine git-with-github usage to adjust the author of the patch. I have cross-checked with already-bcbio-contributor Michael. He would be happy to have this patch under his name but not ultimately desparate if this arrives with my ID. 