### PR TITLE
Fix bug in extracting rRNA features from gtf

### DIFF
--- a/bcbio/rnaseq/gtf.py
+++ b/bcbio/rnaseq/gtf.py
@@ -256,7 +256,7 @@ def get_rRNA(gtf):
                 geneid = _strip_feature_version(geneid)
                 txid = line.split("transcript_id")[1].split(" ")[1]
                 txid = _strip_non_alphanumeric(txid)
-                txid = _strip_feature_version(geneid)
+                txid = _strip_feature_version(txid)
                 features.add((geneid, txid))
     return features
 


### PR DESCRIPTION
Fixes the bug where instead of a geneid/txid pair, there was double geneid output, leading to always 0.0 rRNA rate stat.

cc @ohofmann 