### PR TITLE
run_test.sh - allow for py.test-3 binary, beautification

### DIFF
--- a/bcbio/structural/cn_mops.py
+++ b/bcbio/structural/cn_mops.py
@@ -72,7 +72,7 @@ def _prep_sample_cnvs(cnv_file, data):
     import pybedtools
     sample_name = tz.get_in(["rgnames", "sample"], data)
     def make_names(name):
-        return re.sub("[^\w.]", '.', name)
+        return re.sub(r"[^\w.]", '.', name)
     def matches_sample_name(feat):
         return (feat.name == sample_name or feat.name == "X%s" % sample_name or
                 feat.name == make_names(sample_name))

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,5 +1,6 @@
 """Test individual components of the analysis pipeline.
 """
+from __future__ import print_function
 import os
 import sys
 import shutil

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -53,15 +53,10 @@ if [ -d "../bcbio/pipeline" ]; then
 fi
 
 if [ -z "$PYTEST" ]; then
-	for p in "$BCBIO_DIR/py.test" /usr/bin/py.test-3 /usr/bin/py.test
-	do
-		if [ -x "$p" ]; then
-			PYTEST="$p"
-			break
-		fi
-	done
-	if [ -z "$PYTEST" ]; then
-		echo "E: Could not identify py.test to execute."
-	fi
+	PYTEST="$BCBIO_DIR/py.test"
+fi
+if [ ! -x "$PYTEST" ]; then
+	echo "E: py.test (at '$PYTEST') not found or not executable."
+	exit 1
 fi
 "$PYTEST" -p no:cacheprovider -p no:stepwise -v -s -m ${MARK} "$@"


### PR DESCRIPTION
After updating master, most of my changes for Python V3 were already done :o) I found another regexp missing the "r" prefix at least.

PYTEST can now be specified externally and it looks for the distribution's default py.test install paths. I can understand if you frown about the iteration of py.test locations. It would then be nice if you could still accept the setting via an environment variable.

Cheers,

Steffen