### PR TITLE
Switch to using packaging.version.

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -4,7 +4,7 @@
   GATK -- Next-generation sequence processing.
 """
 from contextlib import closing
-from distutils.version import LooseVersion
+from packaging.version import Version
 import getpass
 import re
 import sys
@@ -301,7 +301,7 @@ class BroadRunner:
                 memscale = config["algorithm"]["memory_adjust"] = {"direction": "increase",
                                                                    "magnitude": max(1, int(cores) // 2)}
         # Filters and unsafe specifications not in GATK4
-        if LooseVersion(self.gatk_major_version()) > LooseVersion("1.9") and not is_gatk4:
+        if Version(self.gatk_major_version()) > Version("1.9") and not is_gatk4:
             if len([x for x in params if x.startswith(("-U", "--unsafe"))]) == 0:
                 params.extend(["-U", "LENIENT_VCF_PROCESSING"])
             params.extend(["--read_filter", "BadCigar", "--read_filter", "NotPrimaryAlignment"])
@@ -345,7 +345,7 @@ class BroadRunner:
         ld_preload injects required libraries for Java JNI calls:
         https://gatkforums.broadinstitute.org/gatk/discussion/8810/something-about-create-pon-workflow
         """
-        needs_java7 = LooseVersion(self.get_gatk_version()) < LooseVersion("3.6")
+        needs_java7 = Version(self.get_gatk_version()) < Version("3.6")
         # For old Java requirements use global java 7
         if needs_java7:
             setpath.remove_bcbiopath()
@@ -410,9 +410,9 @@ class BroadRunner:
         Returns either `lite` (targeting GATK-lite 2.3.9) or `restricted`,
         the latest 2.4+ restricted version of GATK.
         """
-        if LooseVersion(self.gatk_major_version()) > LooseVersion("3.9"):
+        if Version(self.gatk_major_version()) > Version("3.9"):
             return "gatk4"
-        elif LooseVersion(self.gatk_major_version()) > LooseVersion("2.3"):
+        elif Version(self.gatk_major_version()) > Version("2.3"):
             return "restricted"
         else:
             return "lite"

--- a/bcbio/install.py
+++ b/bcbio/install.py
@@ -9,7 +9,7 @@ import collections
 import contextlib
 import datetime
 import dateutil
-from distutils.version import LooseVersion
+from packaging.version import Version
 import gzip
 import json
 import os
@@ -438,14 +438,14 @@ def _is_old_database(db_dir, args):
     """Check for old database versions, supported in snpEff 4.1.
     """
     snpeff_version = effects.snpeff_version(args)
-    if LooseVersion(snpeff_version) >= LooseVersion("4.1"):
+    if Version(snpeff_version) >= Version("4.1"):
         pred_file = os.path.join(db_dir, "snpEffectPredictor.bin")
         if not utils.file_exists(pred_file):
             return True
         with utils.open_gzipsafe(pred_file, is_gz=True) as in_handle:
             version_info = in_handle.readline().strip().split("\t")
         program, version = version_info[:2]
-        if not program.lower() == "snpeff" or LooseVersion(snpeff_version) > LooseVersion(version):
+        if not program.lower() == "snpeff" or Version(snpeff_version) > Version(version):
             return True
     return False
 

--- a/bcbio/provenance/versioncheck.py
+++ b/bcbio/provenance/versioncheck.py
@@ -1,6 +1,6 @@
 """Check specific required program versions required during the pipeline.
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import subprocess
 
 from bcbio import setpath, utils
@@ -51,7 +51,7 @@ def _needs_java(data):
         pass
         # runner = broad.runner_from_config(data["config"])
         # version = runner.get_gatk_version()
-        # if LooseVersion(version) < LooseVersion("3.6"):
+        # if Version(version) < Version("3.6"):
         #     return True
     return False
 
@@ -77,8 +77,8 @@ def java(items):
                     version = version[1:]
                 if version.endswith('"'):
                     version = version[:-1]
-        if (not version or LooseVersion(version) >= LooseVersion(max_version) or
-            LooseVersion(version) < LooseVersion(min_version)):
+        if (not version or Version(version) >= Version(max_version) or
+            Version(version) < Version(min_version)):
             return ("java version %s required for running MuTect and GATK < 3.6.\n"
                     "It needs to be first on your PATH so running 'java -version' give the correct version.\n"
                     "Found version %s at %s" % (min_version, version, java))

--- a/bcbio/rnaseq/stringtie.py
+++ b/bcbio/rnaseq/stringtie.py
@@ -10,7 +10,7 @@ import os
 import pandas as pd
 import subprocess
 import contextlib
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from bcbio.provenance import do
 from bcbio.utils import file_exists
@@ -109,7 +109,7 @@ def version(data):
     with contextlib.closing(subp.stdout) as stdout:
         for line in stdout:
             version = line.decode().strip()
-    return LooseVersion(version)
+    return Version(version)
 
 def supports_merge(data):
     """
@@ -118,4 +118,4 @@ def supports_merge(data):
     which will remove the need for cufflinks merge
     """
     gffcompare_installed = config_utils.program_installed("gffcompare", data)
-    return version(data) >= LooseVersion("1.2.0") and gffcompare_installed
+    return version(data) >= Version("1.2.0") and gffcompare_installed

--- a/bcbio/rnaseq/umi.py
+++ b/bcbio/rnaseq/umi.py
@@ -12,7 +12,7 @@ import glob
 import sys
 import subprocess
 from itertools import repeat, islice
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import bcbio.pipeline.datadict as dd
 from bcbio.pipeline import config_utils
@@ -486,7 +486,7 @@ def has_umi_matrix(data):
     umis_version = version(data)
     if not version:
         return False
-    return LooseVersion(umis_version) >= "1.0.0"
+    return Version(umis_version) >= "1.0.0"
 
 def filter_barcode_histogram(filtered_out_file, out_file, cutoff):
     if file_exists(filtered_out_file):

--- a/bcbio/variation/gatk.py
+++ b/bcbio/variation/gatk.py
@@ -1,7 +1,7 @@
 """GATK variant calling -- HaplotypeCaller and UnifiedGenotyper.
 """
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 import shutil
 import subprocess
 
@@ -31,7 +31,7 @@ def standard_cl_params(items):
         gatk_type = broad_runner.gatk_type()
         if gatk_type == "gatk4":
             out += ["--disable-read-filter", "NotDuplicateReadFilter"]
-        elif LooseVersion(broad_runner.gatk_major_version()) >= LooseVersion("3.5"):
+        elif Version(broad_runner.gatk_major_version()) >= Version("3.5"):
             out += ["-drf", "DuplicateRead"]
     return out
 
@@ -132,7 +132,7 @@ def haplotype_caller(align_bams, items, ref_file, assoc_files,
             params += ["--annotation", "ClippingRankSumTest",
                        "--annotation", "DepthPerSampleHC"]
             # Enable hardware based optimizations in GATK 3.1+
-            if LooseVersion(broad_runner.gatk_major_version()) >= LooseVersion("3.1"):
+            if Version(broad_runner.gatk_major_version()) >= Version("3.1"):
                 if _supports_avx():
                     # Scale down HMM thread default to avoid overuse of cores
                     # https://github.com/bcbio/bcbio-nextgen/issues/2442
@@ -164,7 +164,7 @@ def haplotype_caller(align_bams, items, ref_file, assoc_files,
                     for boundary in [10, 20, 30, 40, 60, 80]:
                         params += ["-GQB", str(boundary)]
             # Enable non-diploid calling in GATK 3.3+
-            if LooseVersion(broad_runner.gatk_major_version()) >= LooseVersion("3.3"):
+            if Version(broad_runner.gatk_major_version()) >= Version("3.3"):
                 params += ["-ploidy", str(ploidy.get_ploidy(items, region))]
             if gatk_type == "gatk4":
                 # GATK4 Spark calling does not support bgzipped output, use plain VCFs

--- a/bcbio/variation/gatkfilter.py
+++ b/bcbio/variation/gatkfilter.py
@@ -2,7 +2,7 @@
 """
 import os
 import gzip
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from bcbio import broad, utils
 from bcbio.distributed.transaction import file_transaction
@@ -269,8 +269,8 @@ def includes_missingalt(data):
     As of GATK 4.1.0.0, variants with missing alts are generated
     (see https://github.com/broadinstitute/gatk/issues/5650)
     """
-    MISSINGALT_VERSION = LooseVersion("4.1.0.0")
-    version = LooseVersion(broad.get_gatk_version(config=dd.get_config(data)))
+    MISSINGALT_VERSION = Version("4.1.0.0")
+    version = Version(broad.get_gatk_version(config=dd.get_config(data)))
     return version >= MISSINGALT_VERSION
 
 def gatk_remove_missingalt(in_file, data):

--- a/bcbio/variation/mutect.py
+++ b/bcbio/variation/mutect.py
@@ -1,6 +1,6 @@
 """Provide support for MuTect and other paired analysis tools."""
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 
 import toolz as tz
@@ -35,7 +35,7 @@ def _check_mutect_version(broad_runner):
         logger.warn("Proceeding but assuming correct version 1.1.5.")
     else:
         try:
-            assert LooseVersion(mutect_version) >= LooseVersion("1.1.5")
+            assert Version(mutect_version) >= Version("1.1.5")
         except AssertionError:
             message = ("MuTect 1.1.4 and lower is known to have incompatibilities "
                        "with Java < 7, and this may lead to problems in analyses. "

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -1,6 +1,6 @@
 """GATK variant calling -- MuTect2.
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 
 import numpy as np
@@ -109,7 +109,7 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
             resources = config_utils.get_resources("mutect2", items[0]["config"])
             if "options" in resources:
                 params += [str(x) for x in resources.get("options", [])]
-            assert LooseVersion(broad_runner.gatk_major_version()) >= LooseVersion("3.5"), \
+            assert Version(broad_runner.gatk_major_version()) >= Version("3.5"), \
                 "Require full version of GATK 3.5+ for mutect2 calling"
             broad_runner.new_resources("mutect2")
             gatk_cmd = broad_runner.cl_gatk(params, os.path.dirname(tx_out_file))

--- a/bcbio/variation/recalibrate.py
+++ b/bcbio/variation/recalibrate.py
@@ -6,7 +6,7 @@ error rates based on alignments to the reference genome.
 http://www.broadinstitute.org/gsa/wiki/index.php/Base_quality_score_recalibration
 """
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import toolz as tz
 
@@ -170,7 +170,7 @@ def _gatk_apply_bqsr(data):
             # https://github.com/bcbio/bcbio-nextgen/issues/2145#issuecomment-343095357
             if gatk_type == "gatk4":
                 params += ["--jdk-deflater", "--jdk-inflater"]
-            elif LooseVersion(broad_runner.gatk_major_version()) > LooseVersion("3.7"):
+            elif Version(broad_runner.gatk_major_version()) > Version("3.7"):
                 params += ["-jdk_deflater", "-jdk_inflater"]
             memscale = {"magnitude": 0.9 * cores, "direction": "increase"} if cores > 1 else None
             broad_runner.run_gatk(params, os.path.dirname(tx_out_file), memscale=memscale,

--- a/bcbio/variation/samtools.py
+++ b/bcbio/variation/samtools.py
@@ -3,7 +3,7 @@
 http://www.htslib.org/workflow/#mapping_to_variant
 """
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from bcbio.utils import file_exists
 from bcbio.distributed.transaction import file_transaction
@@ -76,7 +76,7 @@ def _call_variants_samtools(align_bams, ref_file, items, target_regions, tx_out_
                            target_regions=target_regions, want_bcf=True)
     bcftools = config_utils.get_program("bcftools", config)
     samtools_version = programs.get_version("samtools", config=config)
-    if samtools_version and LooseVersion(samtools_version) <= LooseVersion("0.1.19"):
+    if samtools_version and Version(samtools_version) <= Version("0.1.19"):
         raise ValueError("samtools calling not supported with pre-1.0 samtools")
     bcftools_opts = "call -v -m"
     compress_cmd = "| bgzip -c" if tx_out_file.endswith(".gz") else ""

--- a/bcbio/variation/validateplot.py
+++ b/bcbio/variation/validateplot.py
@@ -6,7 +6,7 @@ differences.
 import collections
 import os
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import numpy as np
 import pandas as pd
 
@@ -67,7 +67,7 @@ def _do_classifyplot(df, out_file, title=None, size=None, samples=None, callers=
     metric_labels = {"fdr": "False discovery rate",
                      "fnr": "False negative rate"}
     metrics = [("fnr", "tpr"), ("fdr", "spc")]
-    is_mpl2 = LooseVersion(mpl.__version__) >= LooseVersion('2.0')
+    is_mpl2 = Version(mpl.__version__) >= Version('2.0')
     colors = ["light grey", "greyish"] * 10
     data_dict = df.set_index(["sample", "caller", "vtype"]).T.to_dict()
     plt.ioff()

--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -11,7 +11,7 @@ https://github.com/AstraZeneca-NGS/VarDict
 
 specify 'vardict-perl'.
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import os
 import sys
 from six.moves import zip
@@ -45,11 +45,11 @@ def _vardict_options_from_config(items, config, out_file, target=None, is_rnaseq
     vardict_cl = get_vardict_command(items[0])
     version = programs.get_version_manifest(vardict_cl)
     if (vardict_cl and version and
-        ((vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.5")) or
-         (vardict_cl == "vardict" and LooseVersion(version) >= LooseVersion("2018.07.25")))):
+        ((vardict_cl == "vardict-java" and Version(version) >= Version("1.5.5")) or
+         (vardict_cl == "vardict" and Version(version) >= Version("2018.07.25")))):
         opts += ["--nosv"]
     if (vardict_cl and version and
-         (vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.6"))):
+         (vardict_cl == "vardict-java" and Version(version) >= Version("1.5.6"))):
         opts += ["--deldupvar"]
     # remove low mapping quality reads
     if not is_rnaseq:

--- a/bcbio/variation/vfilter.py
+++ b/bcbio/variation/vfilter.py
@@ -1,6 +1,6 @@
 """Cutoff-based soft filtering of genomic variants.
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 import math
 import os
 import shutil
@@ -62,7 +62,7 @@ def _freebayes_custom(in_file, ref_file, data):
         return None
     config = data["config"]
     bv_ver = programs.get_version("bcbio_variation", config=config)
-    if LooseVersion(bv_ver) < LooseVersion("0.1.1"):
+    if Version(bv_ver) < Version("0.1.1"):
         return None
     out_file = "%s-filter%s" % os.path.splitext(in_file)
     if not utils.file_exists(out_file):


### PR DESCRIPTION
LooseVersion is apparently not intended for outside code use,
and there are some issues with comparing versions with and
without strings in LooseVersion that they will not fix.

See https://bugs.python.org/issue14894 for the discussion.

packaging is a third-party package that does version checking, it
is python specific and follows this: https://www.python.org/dev/peps/pep-0440/
which looks like it should handle the cases we are looking for.

For example:

V1 = Version("4.1.0.0")
V2  = Version("4.2a")
V3 = Version("4.1.0.0a")

V2 > V1: True
V3 >= V1: False
V3 <= V1: True

This should address the issue in #2806.

@chapmanb what do you think about this way of handling it? 