### PR TITLE
[PoC] Use Mutect2's new read model for filtering

### DIFF
--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -112,8 +112,8 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
                 orientation_filter = False
 
             if gatk_type == "gatk4" and orientation_filter:
-                f1r2_file = "{}.tar.gz".format(
-                    utils.splitext_plus(align_bams[0])[0])
+                f1r2_file = "{}-f1r2.tar.gz".format(
+                    utils.splitext_plus(tx_out_file))
                 params += ["--f1r2-tar-gz", f1r2_file]
 
             # Avoid adding dbSNP/Cosmic so they do not get fed to variant filtering algorithm

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -106,7 +106,7 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
             params += _add_tumor_params(paired, items, gatk_type)
             params += _add_region_params(region, out_file, items, gatk_type)
 
-            if is_paired(align_bams[0]):
+            if all(is_paired(bam) for bam in align_bams):
                 orientation_filter = True
             else:
                 orientation_filter = False

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -106,7 +106,10 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
             params += _add_tumor_params(paired, items, gatk_type)
             params += _add_region_params(region, out_file, items, gatk_type)
 
-            if all(is_paired(bam) for bam in align_bams):
+
+            if all(is_paired(bam) for bam in align_bams) and (
+                    "mutect2_readmodel" in utils.get_in(items[0], "config",
+                                                        "tools_on")):
                 orientation_filter = True
             else:
                 orientation_filter = False

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -113,7 +113,7 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
 
             if gatk_type == "gatk4" and orientation_filter:
                 f1r2_file = "{}-f1r2.tar.gz".format(
-                    utils.splitext_plus(tx_out_file))
+                    utils.splitext_plus(out_file)[0])
                 params += ["--f1r2-tar-gz", f1r2_file]
 
             # Avoid adding dbSNP/Cosmic so they do not get fed to variant filtering algorithm


### PR DESCRIPTION
According to the GATK's doc, Mutect2 can detect read orientation
artifacts (such as stand bias caused by FFPE, or by Illumina Novaseq)
and improve results.

This is a proof of concept (completely untested at this point). In
particular this is posted for early review.

Some important points to act on:

- Do we want this on at all times (GATK says it won't hurt performance)?
- How do we make sure this is only run for paired-end samples (see
FIXME)?
- Is the current simplistic logic for file names acceptable?

This will fix issue #2846.