### PR TITLE
Fix setting CNVkit options in configuration

### DIFF
--- a/bcbio/structural/cnvkit.py
+++ b/bcbio/structural/cnvkit.py
@@ -317,8 +317,8 @@ def _cnvkit_segment(cnr_file, cov_interval, data, items, out_file=None, detailed
                     cmd += ["--vcf", small_vrn_files[0].name, "--sample-id", small_vrn_files[0].sample]
                     if small_vrn_files[0].normal:
                         cmd += ["--normal-id", small_vrn_files[0].normal]
-                resources = config_utils.get_resources("cnvkit_segment", data["config"])
-                user_options = resources.get("options", [])
+                resources = config_utils.get_resources("options", data["config"])
+                user_options = resources.get("cnvkit_segment", [])
                 cmd += [str(x) for x in user_options]
                 if cov_interval == "genome" and "--threshold" not in user_options:
                     cmd += ["--threshold", "0.00001"]


### PR DESCRIPTION
In #2402, an (undocumented by design) option was set to allow the use of
alternative segmentation methods by CNVkit. However, the logic of
extracting configuration was swapped, thus options were never set.

For a typical YAML:

```yaml
resources:
  options:
    cnvkit_segment: [--drop-low-coverage, -m, hmm]
```

Before:

```python
resources = config_utils.get_resources("cnvkit_segment", data["config"])
user_options = resources.get("options", [])
```

The first option would not pick up "cnvkit_segment", but only the
fallback inside `get_resources`, so `user_options` would always be
empty.

After:

```python
resources = config_utils.get_resources("options", data["config"])
user_options = resources.get("cnvkit_segment", [])
```

And like this they are correctly set.