### PR TITLE
Add support for germline resources (from gnomAD) in Mutect2

### DIFF
--- a/bcbio/pipeline/datadict.py
+++ b/bcbio/pipeline/datadict.py
@@ -207,6 +207,9 @@ LOOKUPS = {
     "tools_off": {"keys": ["config", "algorithm", "tools_off"], "default": [], "always_list": True},
     "tools_on": {"keys": ["config", "algorithm", "tools_on"], "default": [], "always_list": True},
     "cwl_reporting": {"keys": ["config", "algorithm", "cwl_reporting"]},
+    "gnomad_exome_file": {"keys": ["genome_resources", "variation",
+                                   "gnomad_exome"],
+                          "checker": file_exists}
 }
 
 def get_background_cnv_reference(data, caller):

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -109,7 +109,7 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
             # Add a germline resource (gnomAD exomes) if available to improve
             # runtime and reduce artifacts(GH#2873)
             gnomad = dd.get_gnomad_exome_file(items[0])
-            if gnomad is not None:
+            if gatk_type == "gatk4" and gnomad is not None:
                 params += ["--germline-resource", gnomad]
 
             if all(is_paired(bam) for bam in align_bams) and (

--- a/bcbio/variation/mutect2.py
+++ b/bcbio/variation/mutect2.py
@@ -106,6 +106,11 @@ def mutect2_caller(align_bams, items, ref_file, assoc_files,
             params += _add_tumor_params(paired, items, gatk_type)
             params += _add_region_params(region, out_file, items, gatk_type)
 
+            # Add a germline resource (gnomAD exomes) if available to improve
+            # runtime and reduce artifacts(GH#2873)
+            gnomad = dd.get_gnomad_exome_file(items[0])
+            if gnomad is not None:
+                params += ["--germline-resource", gnomad]
 
             if all(is_paired(bam) for bam in align_bams) and (
                     "mutect2_readmodel" in utils.get_in(items[0], "config",


### PR DESCRIPTION
If available, the gnomAD exome file will be passed to Mutect2 to avoid
calling sites which are already known to be germline. This will
be mostly useful for tumor-only runs because known sites are not called
at all, but could also be useful for paired runs.