### PR TITLE
bump vep resources to v98

### DIFF
--- a/bcbio/variation/effects.py
+++ b/bcbio/variation/effects.py
@@ -179,7 +179,7 @@ def run_vep(in_file, data):
                     for plugin in plugins:
                         plugin_args = plugin_fns[plugin](data)
                         config_args += plugin_args
-                    config_args += ["--sift", "b", "--polyphen", "b"]
+                    config_args += ["--sift", "b", "--polyphen", "b", "--humdiv"]
                     if hgvs_compatible:
                         config_args += ["--hgvsg", "--hgvs", "--shift_hgvs", "1"]
                 if (dd.get_effects_transcripts(data).startswith("canonical")

--- a/config/genomes/BDGP6-resources.yaml
+++ b/config/genomes/BDGP6-resources.yaml
@@ -1,5 +1,5 @@
-version: 18
+version: 19
 
 aliases:
-  ensembl: drosophila_melanogaster_vep_97_BDGP6.22
+  ensembl: drosophila_melanogaster_vep_98_BDGP6.22
   snpeff: BDGP6.86

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -6,7 +6,7 @@ aliases:
   ensembl: homo_sapiens_merged_vep_98_GRCh37
 
 variation:
-  dbsnp: ../variation/dbsnp-152.vcf.gz
+  dbsnp: ../variation/dbsnp-151.vcf.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/GRCh37-resources.yaml
+++ b/config/genomes/GRCh37-resources.yaml
@@ -1,12 +1,12 @@
-version: 51
+version: 52
 
 aliases:
   human: true
   snpeff: GRCh37.75
-  ensembl: homo_sapiens_merged_vep_97_GRCh37
+  ensembl: homo_sapiens_merged_vep_98_GRCh37
 
 variation:
-  dbsnp: ../variation/dbsnp-151.vcf.gz
+  dbsnp: ../variation/dbsnp-152.vcf.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/GRCz11-resources.yaml
+++ b/config/genomes/GRCz11-resources.yaml
@@ -1,5 +1,5 @@
-version: 5
+version: 6
 
 aliases:
-  ensembl: danio_rerio_vep_97_GRCz11
+  ensembl: danio_rerio_vep_98_GRCz11
   #snpeff: 

--- a/config/genomes/Sscrofa11.1-resources.yaml
+++ b/config/genomes/Sscrofa11.1-resources.yaml
@@ -1,5 +1,5 @@
-version: 5
+version: 6
 
 aliases:
-  ensembl: sus_scrofa_vep_97_Sscrofa11.1
+  ensembl: sus_scrofa_vep_98_Sscrofa11.1
   #snpeff: 

--- a/config/genomes/WBcel235-resources.yaml
+++ b/config/genomes/WBcel235-resources.yaml
@@ -1,5 +1,5 @@
-version: 16
+version: 17
 
 aliases:
-  ensembl: caenorhabditis_elegans_vep_97_WBcel235
+  ensembl: caenorhabditis_elegans_vep_98_WBcel235
   snpeff: WBcel235.86

--- a/config/genomes/canFam3-resources.yaml
+++ b/config/genomes/canFam3-resources.yaml
@@ -1,7 +1,7 @@
-version: 23
+version: 24
 
 aliases:
-  ensembl: canis_familiaris_vep_97_CanFam3.1
+  ensembl: canis_familiaris_vep_98_CanFam3.1
   snpeff: CanFam3.1.86
 
 variation:

--- a/config/genomes/dm3-resources.yaml
+++ b/config/genomes/dm3-resources.yaml
@@ -1,5 +1,5 @@
-version: 18
+version: 19
 
 aliases:
-  ensembl: drosophila_melanogaster_vep_97_BDGP6.22
+  ensembl: drosophila_melanogaster_vep_98_BDGP6.22
   snpeff: BDGP6.86

--- a/config/genomes/galGal4-resources.yaml
+++ b/config/genomes/galGal4-resources.yaml
@@ -1,5 +1,5 @@
-version: 12
+version: 13
 
 aliases:
-  ensembl: gallus_gallus_vep_97_Galgal4
+  ensembl: gallus_gallus_vep_98_Galgal4
   snpeff: Galgal4.75

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -6,7 +6,7 @@ aliases:
   ensembl: homo_sapiens_merged_vep_98_GRCh37
 
 variation:
-  dbsnp: ../variation/dbsnp-152.vcf.gz
+  dbsnp: ../variation/dbsnp-151.vcf.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg19-resources.yaml
+++ b/config/genomes/hg19-resources.yaml
@@ -1,12 +1,12 @@
-version: 53
+version: 54
 
 aliases:
   human: true
   snpeff: GRCh37.75
-  ensembl: homo_sapiens_merged_vep_97_GRCh37
+  ensembl: homo_sapiens_merged_vep_98_GRCh37
 
 variation:
-  dbsnp: ../variation/dbsnp-151.vcf.gz
+  dbsnp: ../variation/dbsnp-152.vcf.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz
   train_omni: ../variation/1000G_omni2.5.vcf.gz
   train_1000g: ../variation/1000G_phase1.snps.high_confidence.vcf.gz

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -6,7 +6,7 @@ aliases:
   ensembl: homo_sapiens_merged_vep_98_GRCh38
 
 variation:
-  dbsnp: ../variation/dbsnp-152.vcf.gz
+  dbsnp: ../variation/dbsnp-151.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbscsnv: ../variation/dbscSNV.txt.gz
   genesplicer: ../variation/genesplicer

--- a/config/genomes/hg38-noalt-resources.yaml
+++ b/config/genomes/hg38-noalt-resources.yaml
@@ -1,12 +1,12 @@
-version: 27
+version: 28
 
 aliases:
   human: true
   snpeff: GRCh38.86
-  ensembl: homo_sapiens_merged_vep_97_GRCh38
+  ensembl: homo_sapiens_merged_vep_98_GRCh38
 
 variation:
-  dbsnp: ../variation/dbsnp-151.vcf.gz
+  dbsnp: ../variation/dbsnp-152.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbscsnv: ../variation/dbscSNV.txt.gz
   genesplicer: ../variation/genesplicer

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -3,10 +3,10 @@ version: 38
 aliases:
   human: true
   snpeff: GRCh38.86
-  ensembl: homo_sapiens_merged_vep_97_GRCh38
+  ensembl: homo_sapiens_merged_vep_98_GRCh38
 
 variation:
-  dbsnp: ../variation/dbsnp-151.vcf.gz
+  dbsnp: ../variation/dbsnp-152.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbscsnv: ../variation/dbscSNV.txt.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz

--- a/config/genomes/hg38-resources.yaml
+++ b/config/genomes/hg38-resources.yaml
@@ -6,7 +6,7 @@ aliases:
   ensembl: homo_sapiens_merged_vep_98_GRCh38
 
 variation:
-  dbsnp: ../variation/dbsnp-152.vcf.gz
+  dbsnp: ../variation/dbsnp-151.vcf.gz
   dbnsfp: ../variation/dbNSFP.txt.gz
   dbscsnv: ../variation/dbscSNV.txt.gz
   train_hapmap: ../variation/hapmap_3.3.vcf.gz

--- a/config/genomes/mm10-resources.yaml
+++ b/config/genomes/mm10-resources.yaml
@@ -1,8 +1,8 @@
-version: 30
+version: 31
 
 aliases:
   snpeff: GRCm38.86
-  ensembl: mus_musculus_vep_97_GRCm38
+  ensembl: mus_musculus_vep_98_GRCm38
 
 variation:
   dbsnp: ../variation/mm10-dbSNP-2013-09-12.vcf.gz

--- a/config/genomes/rn6-resources.yaml
+++ b/config/genomes/rn6-resources.yaml
@@ -1,7 +1,7 @@
-version: 15
+version: 16
 
 aliases:
-  ensembl: rattus_norvegicus_vep_97_Rnor_6.0
+  ensembl: rattus_norvegicus_vep_98_Rnor_6.0
   snpeff: Rnor_6.0.86
 rnaseq:
   transcripts: ../rnaseq/ref-transcripts.gtf

--- a/config/genomes/sacCer3-resources.yaml
+++ b/config/genomes/sacCer3-resources.yaml
@@ -1,7 +1,7 @@
-version: 19
+version: 20
 
 aliases:
-  ensembl: saccharomyces_cerevisiae_vep_97_R64-1-1
+  ensembl: saccharomyces_cerevisiae_vep_98_R64-1-1
   snpeff: R64-1-1.86
 rnaseq:
   transcripts: ../rnaseq/ref-transcripts.gtf

--- a/config/genomes/xenTro3-resources.yaml
+++ b/config/genomes/xenTro3-resources.yaml
@@ -1,5 +1,5 @@
-version: 18
+version: 19
 
 aliases:
-  ensembl: xenopus_tropicalis_vep_97_JGI_4.2
+  ensembl: xenopus_tropicalis_vep_98_JGI_4.2
   snpeff: JGI_4.2.86


### PR DESCRIPTION
- bump vep to v98
- added `humdiv` option to VEP, as it should be better for discovery for rare mendelian disease, see [the blog](http://www.ensembl.info/2019/10/03/cool-stuff-the-ensembl-vep-can-do-predict-pathogenicity-of-missense-variants/)
- added and reverted a dbsnp bump due to weird formatting in the dbsnp 152 vcf.

Cheers
M