### PR TITLE
add --twopassMode Basic to star.py

### DIFF
--- a/bcbio/ngsalign/star.py
+++ b/bcbio/ngsalign/star.py
@@ -70,6 +70,7 @@ def align(fastq_file, pair_file, ref_file, names, align_dir, data):
                "--runThreadN {num_cores} --outFileNamePrefix {tx_out_prefix} "
                "--outReadsUnmapped Fastx --outFilterMultimapNmax {max_hits} "
                "--outStd BAM_Unsorted {srna_opts} "
+               "--twopassMode Basic "
                "--limitOutSJcollapsed 2000000 "
                "--outSAMtype BAM Unsorted "
                "--outSAMmapqUnique 60 "


### PR DESCRIPTION
somehow it has been lost last time.

passes tests ok, however, fails Arriba test:

```
[2019-11-15T00:59Z] Reading chimeric alignments from '/home/ubuntu/naumenko/code/bcbio-nextgen/tests/test_automated_output/align/Test1/Test1_star/Test1.bam'ERROR: no normal reads found
[2019-11-15T00:59Z] Uncaught exception occurred
Traceback (most recent call last):
  File "/bcbio/anaconda/lib/python3.6/site-packages/bcbio_nextgen-1.1.9a0-py3.6.egg/bcbio/provenance/do.py", line 26, in run
    _do_run(cmd, checks, log_stdout, env=env)
  File "/bcbio/anaconda/lib/python3.6/site-packages/bcbio_nextgen-1.1.9a0-py3.6.egg/bcbio/provenance/do.py", line 106, in _do_run
    raise subprocess.CalledProcessError(exitcode, error_msg)
subprocess.CalledProcessError: Command 'set -o pipefail; /bcbio/tools/bin/arriba -x /home/ubuntu/naumenko/code/bcbio-nextgen/tests/test_automated_output/align/Test1/Test1_star/Test1.bam -g /home/ubuntu/naumenko/code/bcbio-nextgen/tests/data/genomes/hg19/rnaseq/ref-transcripts.gtf -a /home/ubuntu/naumenko/code/bcbio-nextgen/tests/data/genomes/hg19/seq/hg19.fa -o /home/ubuntu/naumenko/code/bcbio-nextgen/tests/test_automated_output/bcbiotx/tmpf1n60koe/fusions.tsv -O /home/ubuntu/naumenko/code/bcbio-nextgen/tests/test_automated_output/bcbiotx/tmprw_kunu4/fusions.discarded.tsv -i chr22 -f blacklist 
Loading annotation from '/home/ubuntu/naumenko/code/bcbio-nextgen/tests/data/genomes/hg19/rnaseq/ref-transcripts.gtf'
Loading assembly from '/home/ubuntu/naumenko/code/bcbio-nextgen/tests/data/genomes/hg19/seq/hg19.fa'
Reading chimeric alignments from '/home/ubuntu/naumenko/code/bcbio-nextgen/tests/test_automated_output/align/Test1/Test1_star/Test1.bam'ERROR: no normal reads found
' returned non-zero exit status 1.
```