### PR TITLE
remove directory param from torque qsub

### DIFF
--- a/bcbio/cwl/hpc.py
+++ b/bcbio/cwl/hpc.py
@@ -427,7 +427,8 @@ HPC_CONFIGS = {
         %(cwl_attrs)s
         \"\"\"
         submit = \"\"\"
-        qsub -V -d ${cwd} -N ${job_name} -o ${out} -e ${err} -q ${queue} \
+        cd ${cwd} && \
+        qsub -V -N ${job_name} -o ${out} -e ${err} -q ${queue} \
         -l nodes=1:ppn=${cpu} -l mem=${memory_mb}mb -l walltime=${walltime} \
         ${script}
         \"\"\"


### PR DESCRIPTION
Cromwell creates directory trees with long names, which causes torque to throw
```
qsub: -d arg is longer than 256 characters
usage: qsub [-a date_time] [-A account_string] [-b secs]
      [-c [ none | { enabled | periodic | shutdown |
      depth=<int> | dir=<path> | interval=<minutes>}... ]
      [-C directive_prefix] [-d path] [-D path]
      [-e path] [-h] [-I] [-j oe] [-k {oe}] [-l resource_list] [-m n|{abe}]
      [-M user_list] [-N jobname] [-o path] [-p priority] [-P proxy_user] [-q queue] 
      [-r y|n] [-S path] [-t number_to_submit] [-T type]  [-u user_list] [-w] path
      [-W otherattributes=value...] [-v variable_list] [-V ] [-x] [-X] [-z] [script]
```

`cd`-ing to the directory beforehand fixes this.

Cheers
M