### PR TITLE
add support of miRNA data to BDGP6

### DIFF
--- a/config/genomes/BDGP6-resources.yaml
+++ b/config/genomes/BDGP6-resources.yaml
@@ -1,5 +1,11 @@
-version: 21
+version: 22
 
 aliases:
   ensembl: drosophila_melanogaster_vep_99_BDGP6.28
   snpeff: BDGP6.86
+  
+  srnaseq:
+    srna_transcripts: ../srnaseq/srna-transcripts.gtf
+    mirbase_hairpin: ../srnaseq/hairpin.fa
+    mirbase_mature: ../srnaseq/mature.fa
+    mirdeep2_fasta: ../srnaseq/Rfam_for_miRDeep.fa


### PR DESCRIPTION
Hi,
here my PR to add support of miRNA analysis with BDGP6 genome.
Related to this [bcbio issue #3112 ](https://github.com/bcbio/bcbio-nextgen/issues/3112) and PR to the cloudbiolinux https://github.com/chapmanb/cloudbiolinux/pull/344