### PR TITLE
Fix indentations in srnaseq resources of BDGP6

### DIFF
--- a/config/genomes/BDGP6-resources.yaml
+++ b/config/genomes/BDGP6-resources.yaml
@@ -4,8 +4,8 @@ aliases:
   ensembl: drosophila_melanogaster_vep_99_BDGP6.28
   snpeff: BDGP6.86
   
-  srnaseq:
-    srna_transcripts: ../srnaseq/srna-transcripts.gtf
-    mirbase_hairpin: ../srnaseq/hairpin.fa
-    mirbase_mature: ../srnaseq/mature.fa
-    mirdeep2_fasta: ../srnaseq/Rfam_for_miRDeep.fa
+srnaseq:
+  srna_transcripts: ../srnaseq/srna-transcripts.gtf
+  mirbase_hairpin: ../srnaseq/hairpin.fa
+  mirbase_mature: ../srnaseq/mature.fa
+  mirdeep2_fasta: ../srnaseq/Rfam_for_miRDeep.fa


### PR DESCRIPTION
Fixing the bug indentations preventing the execution of smallRNA-seq analysis for BDGP6 (see [this comment of issue #3112 ](https://github.com/bcbio/bcbio-nextgen/issues/3112#issuecomment-594697863))