### PR TITLE
dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,43 @@
-FROM stackbrew/ubuntu:14.04
-MAINTAINER Brad Chapman "https://github.com/chapmanb"
+FROM debian:stretch-slim
+LABEL maintainer="BcBio Maintainers (https://github.com/bcbio/bcbio-nextgen)"
 
 # Setup a base system
 RUN apt-get update && \
-    apt-get install -y curl wget git unzip tar gzip bzip2 xz-utils pigz && \
-# Support inclusion in Arvados pipelines
-    apt-get install -y --no-install-recommends libcurl4-gnutls-dev mbuffer python2.7-dev python-virtualenv && \
-# Not added by default to save space
-#   apt-get install -y libglu1-mesa && \
+    apt-get install -y wget python git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 # bcbio-nextgen installation
-    mkdir -p /tmp/bcbio-nextgen-install && cd /tmp/bcbio-nextgen-install && \
+RUN mkdir -p /tmp/bcbio-nextgen-install && \
+    cd /tmp/bcbio-nextgen-install && \
     wget --no-check-certificate \
       https://raw.githubusercontent.com/bcbio/bcbio-nextgen/master/scripts/bcbio_nextgen_install.py && \
-    python bcbio_nextgen_install.py /usr/local/share/bcbio-nextgen \
-      --isolate --minimize-disk --nodata -u development && \
-    git config --global url.https://github.com/.insteadOf git://github.com/ && \
-    /usr/local/share/bcbio-nextgen/anaconda/bin/conda install -y nomkl && \
-    /usr/local/share/bcbio-nextgen/anaconda/bin/bcbio_nextgen.py upgrade --isolate --tooldir=/usr/local --tools && \
-    /usr/local/share/bcbio-nextgen/anaconda/bin/bcbio_nextgen.py upgrade --isolate -u development --tools && \
-    # Remove larger packages not used consistently in bcbio Docker runs
-    /usr/local/share/bcbio-nextgen/anaconda/bin/conda remove --force -y hap.py && \
-    /usr/local/share/bcbio-nextgen/anaconda/bin/conda remove --force -y bioconductor-org.hs.eg.db bioconductor-org.mm.eg.db bioconductor-go.db && \
-
-# setup paths
+    python bcbio_nextgen_install.py \
+      /usr/local/share/bcbio-nextgen \
+      --tooldir=/usr/local \
+      --isolate \
+      --minimize-disk \
+      --nodata \
+      -u development && \
+# setup paths and cleanup
     echo 'export PATH=/usr/local/bin:$PATH' >> /etc/profile.d/bcbio.sh && \
+    /usr/local/share/bcbio-nextgen/anaconda/bin/conda clean --yes --all && \
+    rm -rf /tmp/bcbio-nextgen-install
 
 # add user run script
-    wget --no-check-certificate -O createsetuser \
+RUN wget --no-check-certificate -O createsetuser \
       https://raw.githubusercontent.com/bcbio/bcbio-nextgen-vm/master/scripts/createsetuser && \
-    chmod a+x createsetuser && mv createsetuser /sbin && \
-
-# clean filesystem
-    cd /usr/local && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* && \
-    /usr/local/share/bcbio-nextgen/anaconda/bin/conda clean --yes --tarballs && \
-    # Remove large conda packages left behind
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/qt* && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/mysql-5.* && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/hap.py.* && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/scipy-0.19.1-np113py27_nomkl_0 && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/bioconductor-org.*db* && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/pkgs/bioconductor-go.*db* && \
-    rm -rf /usr/local/share/bcbio-nextgen/anaconda/zulu*.tar.gz && \
-    rm -rf /usr/local/.git && \
-    rm -rf /.cpanm && \
-    rm -rf /tmp/bcbio-nextgen-install && \
+    chmod a+x createsetuser && mv createsetuser /sbin
 
 # Create directories and symlinks for data
-    mkdir -p /mnt/biodata && \
-    mkdir -p /tmp/bcbio-nextgen && \
+RUN mkdir -p /mnt/biodata && \
     mv /usr/local/share/bcbio-nextgen/galaxy/bcbio_system.yaml /usr/local/share/bcbio-nextgen/config && \
     rmdir /usr/local/share/bcbio-nextgen/galaxy && \
     ln -s /mnt/biodata/galaxy /usr/local/share/bcbio-nextgen/galaxy && \
     ln -s /mnt/biodata/gemini_data /usr/local/share/bcbio-nextgen/gemini_data && \
     ln -s /mnt/biodata/genomes /usr/local/share/bcbio-nextgen/genomes && \
     ln -s /mnt/biodata/liftOver /usr/local/share/bcbio-nextgen/liftOver && \
-    chmod a+rwx /usr/local/share/bcbio-nextgen && \
-    chmod a+rwx /usr/local/share/bcbio-nextgen/config && \
-    chmod a+rwx /usr/local/share/bcbio-nextgen/config/*.yaml && \
-
+    chmod -R a+rwX /usr/local/share/bcbio-nextgen && \
 # Ensure permissions are set for update in place by arbitrary users
     find /usr/local -perm /u+x -execdir chmod a+x {} \; && \
     find /usr/local -perm /u+w -execdir chmod a+w {} \;


### PR DESCRIPTION
I've removed a bunch of stuff that seemend superflous and tried to streamline the build.
For maximum perfomance on automated builds, I think we should move to a bcbio base image with all dependencies installed and base the automated build on this image.

That way, the auto-build could just `pip install` the latest bcbio codebase into the image and start running tests.
Downside here is that the base image would have to be built and pushed manually.