### PR TITLE
Fix generation of PureCN summary output

### DIFF
--- a/bcbio/heterogeneity/loh.py
+++ b/bcbio/heterogeneity/loh.py
@@ -8,6 +8,7 @@ import os
 import decimal
 import uuid
 
+import pandas as pd
 import six
 from six import StringIO
 import toolz as tz
@@ -135,18 +136,25 @@ def _purecn_summary(call, data):
     """Summarize purity, ploidy and LOH for PureCN.
     """
     out = {}
+    loh_calls = pd.read_csv(call["loh"])
     for svtype, coords in get_coords(data):
         cur_calls = {k: collections.defaultdict(int) for k in coords.keys()}
-        with open(call["loh"]) as in_handle:
-            in_handle.readline()  # header
-            for line in in_handle:
-                _, chrom, start, end, _, cn, minor_cn = line.split(",")[:7]
-                start = int(start)
-                end = int(end)
-                for region, cur_coords in coords.items():
-                    if chrom == cur_coords[0] and are_overlapping((start, end), cur_coords[1:]):
-                        cur_calls[region][_check_copy_number_changes(svtype, _to_cn(cn), _to_cn(minor_cn), data)] += 1
+        
+        for rowid, row in loh_calls.iterrows():
+        
+            _, chrom, start, end, _, cn, minor_cn = row.iloc[0:7]
+            
+            if pd.isnull(cn) or pd.isnull(minor_cn):
+                # NA copy number calls - skip
+                continue
+            
+            start = int(start)
+            end = int(end)
+            for region, cur_coords in coords.items():
+                if chrom == cur_coords[0] and are_overlapping((start, end), cur_coords[1:]):
+                    cur_calls[region][_check_copy_number_changes(svtype, _to_cn(cn), _to_cn(minor_cn), data)] += 1
         out[svtype] = {r: _merge_cn_calls(c, svtype) for r, c in cur_calls.items()}
+        
     with open(call["hetsummary"]) as in_handle:
         vals = dict(zip(in_handle.readline().strip().replace('"', '').split(","),
                         in_handle.readline().strip().split(",")))

--- a/bcbio/heterogeneity/loh.py
+++ b/bcbio/heterogeneity/loh.py
@@ -139,22 +139,18 @@ def _purecn_summary(call, data):
     loh_calls = pd.read_csv(call["loh"])
     for svtype, coords in get_coords(data):
         cur_calls = {k: collections.defaultdict(int) for k in coords.keys()}
-        
         for rowid, row in loh_calls.iterrows():
-        
             _, chrom, start, end, _, cn, minor_cn = row.iloc[0:7]
-            
             if pd.isnull(cn) or pd.isnull(minor_cn):
                 # NA copy number calls - skip
                 continue
-            
             start = int(start)
             end = int(end)
             for region, cur_coords in coords.items():
                 if chrom == cur_coords[0] and are_overlapping((start, end), cur_coords[1:]):
                     cur_calls[region][_check_copy_number_changes(svtype, _to_cn(cn), _to_cn(minor_cn), data)] += 1
         out[svtype] = {r: _merge_cn_calls(c, svtype) for r, c in cur_calls.items()}
-        
+
     with open(call["hetsummary"]) as in_handle:
         vals = dict(zip(in_handle.readline().strip().replace('"', '').split(","),
                         in_handle.readline().strip().split(",")))


### PR DESCRIPTION
The current code did not check if the copy number values were valid
(some can be NA) and thus it would error out when trying to coerce them
with a float.

The easiest solution, since bcbio already depends on pandas, was to
ditch the custom parsing and use pandas to read the file, and skip lines
with missing values.

As a micro optimization, reading the LOH file was put outside the loop,
to reduce needless I/O.