### PR TITLE
Cannot sort [str, str, str, None, bool] in python3

### DIFF
--- a/bcbio/pipeline/run_info.py
+++ b/bcbio/pipeline/run_info.py
@@ -705,7 +705,7 @@ def _check_svcaller(item):
     if len(problem) > 0:
         raise ValueError("Unexpected algorithm 'svcaller' parameters: %s\n"
                          "Supported options: %s\n" % (" ".join(["'%s'" % x for x in problem]),
-                                                      sorted(list(allowed))))
+                                                      list(allowed)))
     if "gatk-cnv" in svs and "cnvkit" in svs:
         raise ValueError("%s uses `gatk-cnv' and 'cnvkit', please use on one of these CNV callers" %
                          dd.get_sample_name(item))


### PR DESCRIPTION
We're getting the error below. I'm pretty sure this is another issue caused by the python2 → python3 upgrade, but maybe undetected so far because people didn't make the same parameter mistake we did. So I just skip sorting the `allowed` list to fix.

 ```
Checking sample YAML configuration: /whatwhat/something_bcbio.yaml
Traceback (most recent call last):
  File "/opt/bcbio/anaconda/bin/bcbio_nextgen.py", line 245, in <module>
    main(**kwargs)
  File "/opt/bcbio/anaconda/bin/bcbio_nextgen.py", line 46, in main
    run_main(**kwargs)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/main.py", line 50, in run_main
    fc_dir, run_info_yaml)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/main.py", line 91, in _run_toplevel
    for xs in pipeline(config, run_info_yaml, parallel, dirs, samples):
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/main.py", line 128, in variant2pipeline
    [x[0]["description"] for x in samples]]])
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/distributed/multi.py", line 28, in run_parallel
    return run_multicore(fn, items, config, parallel=parallel)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/distributed/multi.py", line 86, in run_multicore
    for data in joblib.Parallel(parallel["num_jobs"], batch_size=1, backend="multiprocessing")(joblib.delayed(fn)(*x) for x in items):
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/parallel.py", line 1004, in __call__
    if self.dispatch_one_batch(iterator):
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/parallel.py", line 835, in dispatch_one_batch
    self._dispatch(tasks)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/parallel.py", line 754, in _dispatch
    job = self._backend.apply_async(batch, callback=cb)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/_parallel_backends.py", line 209, in apply_async
    result = ImmediateResult(func)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/_parallel_backends.py", line 590, in __init__
    self.results = batch()
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/parallel.py", line 256, in __call__
    for func, args, kwargs in self.items]
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/joblib/parallel.py", line 256, in <listcomp>
    for func, args, kwargs in self.items]
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/utils.py", line 55, in wrapper
    return f(*args, **kwargs)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/distributed/multitasks.py", line 455, in organize_samples
    return run_info.organize(*args)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/run_info.py", line 62, in organize
    is_cwl=is_cwl, integrations=integrations)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/run_info.py", line 1014, in _run_info_from_yaml
    _check_sample_config(run_details, run_info_yaml, config)
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/run_info.py", line 795, in _check_sample_config
    [_check_svcaller(x) for x in items]
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/run_info.py", line 795, in <listcomp>
    [_check_svcaller(x) for x in items]
  File "/opt/bcbio/anaconda/lib/python3.6/site-packages/bcbio/pipeline/run_info.py", line 708, in _check_svcaller
    sorted(list(allowed))))
TypeError: '<' not supported between instances of 'bool' and 'str'```