### PR TITLE
Viral content: add read counts

### DIFF
--- a/bcbio/qc/viral.py
+++ b/bcbio/qc/viral.py
@@ -5,6 +5,7 @@ inform treatment.
 """
 import glob
 import os
+import subprocess
 
 from bcbio import bam, utils
 from bcbio.distributed.transaction import file_transaction
@@ -40,17 +41,23 @@ def run(bam_file, data, out_dir):
                             "bamsort tmpfile={tmpfile} inputthreads={cores} outputthreads={cores} "
                             "inputformat=sam index=1 indexfilename={tx_out_file}.bai O={tx_out_file}")
                     do.run(cmd.format(**locals()), "Align unmapped reads to viral genome")
+
+            total_reads = _count_reads(bam_file)
+            assert total_reads > 0, 'Reads count is {total_reads}, is there a bug in counting the read count? {bam_file}'.format(**locals())
             with file_transaction(data, out_file) as tx_out_file:
                 sample_name = dd.get_sample_name(data)
                 mosdepth_prefix = os.path.splitext(viral_bam)[0]
                 cmd = ("mosdepth -t {cores} {mosdepth_prefix} {viral_bam} -n --thresholds 1,5,25 --by "
-                        "<(awk 'BEGIN {{FS=\"\\t\"}}; {{print $1 FS \"0\" FS $2}}' {viral_ref}.fai) && "
-                        "echo '## Viral sequences (from {source_link}) found in unmapped reads' > {tx_out_file} &&"
-                        "echo '## Sample: {sample_name}' >> {tx_out_file} && "
-                        "echo '#virus\tsize\tdepth\t1x\t5x\t25x' >> {tx_out_file} && "
-                        "paste <(zcat {mosdepth_prefix}.regions.bed.gz) <(zgrep -v ^# {mosdepth_prefix}.thresholds.bed.gz) | "
-                        "awk 'BEGIN {{FS=\"\\t\"}} {{ print $1 FS $3 FS $4 FS $10/$3 FS $11/$3 FS $12/$3}}' | "
-                        "sort -n -r -k 5,5 >> {tx_out_file}")
+                       "<(awk 'BEGIN {{FS=\"\\t\"}}; {{print $1 FS \"0\" FS $2}}' {viral_ref}.fai) && "
+                       "echo '## Viral sequences (from {source_link}) found in unmapped reads' > {tx_out_file} &&"
+                       "echo '## Sample: {sample_name}' >> {tx_out_file} && "
+                       "echo '#virus\tsize\tdepth\t1x\t5x\t25x\treads\treads_pct' >> {tx_out_file} && "
+                       "paste "
+                       "<(zcat {mosdepth_prefix}.regions.bed.gz) "
+                       "<(zgrep -v ^# {mosdepth_prefix}.thresholds.bed.gz) "
+                       "<(samtools idxstats {viral_bam} | grep -v '*') | "
+                       "awk 'BEGIN {{FS=\"\\t\"}} {{ print $1 FS $3 FS $4 FS $10/$3 FS $11/$3 FS $12/$3 FS $15 FS $15/{total_reads}}}' | "
+                       "sort -n -r -k 5,5 >> {tx_out_file}")
                 do.run(cmd.format(**locals()), "Analyse coverage of viral genomes")
                 if chromhacks.get_EBV(data):
                     ref_file = dd.get_ref_file(data)
@@ -59,8 +66,11 @@ def run(bam_file, data, out_dir):
                     mosdepth_prefix = os.path.splitext(work_bam)[0] + "-EBV"
                     cmd = ("mosdepth -t {cores} {mosdepth_prefix} {work_bam} -n --thresholds 1,5,25 --by "
                             "<(grep {ebv} {ref_file}.fai | awk 'BEGIN {{FS=\"\\t\"}}; {{print $1 FS \"0\" FS $2}}') && "
-                            "paste <(zcat {mosdepth_prefix}.regions.bed.gz) <(zgrep -v ^# {mosdepth_prefix}.thresholds.bed.gz) | "
-                            "awk 'BEGIN {{FS=\"\\t\"}} {{ print $1 FS $3 FS $4 FS $10/$3 FS $11/$3 FS $12/$3}}' | "
+                            "paste "
+                            "<(zcat {mosdepth_prefix}.regions.bed.gz) "
+                            "<(zgrep -v ^# {mosdepth_prefix}.thresholds.bed.gz) "
+                            "<(samtools idxstats {work_bam} | grep {ebv}) | "
+                            "awk 'BEGIN {{FS=\"\\t\"}} {{ print $1 FS $3 FS $4 FS $10/$3 FS $11/$3 FS $12/$3 FS $15 FS $15/{total_reads}}}' | "
                             "sort -n -r -k 5,5 >> {tx_out_file}")
                     do.run(cmd.format(**locals()), "Analyse coverage of EBV")
 
@@ -74,3 +84,8 @@ def get_files(data):
     all_files = glob.glob(os.path.normpath(os.path.join(os.path.dirname(dd.get_ref_file(data)),
                                                         os.pardir, "viral", "*")))
     return sorted(all_files)
+
+def _count_reads(bam_file):
+    cmd = "samtools idxstats %s | awk '{sum += $3 + $4} END {print sum}'"
+    count = subprocess.check_output(cmd % bam_file, shell=True)
+    return int(count.strip())


### PR DESCRIPTION
Added the read count and read percentage mapped to a virus, to address the request at https://github.com/bcbio/bcbio-nextgen/issues/3154

I also added some required `setuptools.setup()` parameters at `setup.py` to enable installation with pip, it really helps with development. Hope it doesn't break anything.