### PR TITLE
Prevent silent updates of Miniconda during installation

### DIFF
--- a/scripts/bcbio_nextgen_install.py
+++ b/scripts/bcbio_nextgen_install.py
@@ -27,12 +27,8 @@ REMOTES = {
     "gitrepo": "https://github.com/bcbio/bcbio-nextgen.git",
     "system_config":
         "https://raw.githubusercontent.com/bcbio/bcbio-nextgen/master/config/bcbio_system.yaml",
-    "anaconda": "https://repo.continuum.io/miniconda/Miniconda3-latest-%s-x86_64.sh"
+    "anaconda": "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-%s-x86_64.sh"
 }
-# required to prevent potential incompatibility with conda packages that expect 3.7 or below
-# however, this may cause future issues with conda when it is upgraded to 3.8 or above
-# for example: https://github.com/bcbio/bcbio-nextgen/issues/3240
-TARGETPY = 'python=3.7'
 
 
 def main(args, sys_argv):
@@ -105,10 +101,9 @@ def install_conda_pkgs(anaconda, args):
         subprocess.check_call(["wget", "--no-check-certificate", REMOTES["requirements"]])
     if args.minimize_disk:
         subprocess.check_call([mamba_bin, "install", "--yes", "nomkl"], env=env)
-    subprocess.check_call([mamba_bin, "install", "--yes", "--only-deps", "bcbio-nextgen",
-                           TARGETPY], env=env)
+    subprocess.check_call([mamba_bin, "install", "--yes", "--only-deps", "bcbio-nextgen"], env=env)
     subprocess.check_call([conda_bin, "install", "--yes",
-                           "--file", os.path.basename(REMOTES["requirements"]), TARGETPY], env=env)
+                           "--file", os.path.basename(REMOTES["requirements"])], env=env)
     return os.path.join(anaconda["dir"], "bin", "bcbio_nextgen.py")
 
 


### PR DESCRIPTION
* Specify exact Miniconda version in the installer to prevent issues like #3240 
* Simplify installer code (toward #3191)
* Update Conda repo URL
