### PR TITLE
Corrected the omission of *-resources.yaml

### DIFF
--- a/bcbio/cwl/create.py
+++ b/bcbio/cwl/create.py
@@ -761,7 +761,7 @@ def _item_to_cwldata(x, get_retriever, indexes=None):
             elif x.endswith((".vcf.gz", ".bed.gz")):
                 out = _add_secondary_if_exists([x + ".tbi"], out, get_retriever)
             elif x.endswith(".fa"):
-                out = _add_secondary_if_exists([x + ".fai", os.path.splitext(x)[0] + ".dict"], out, get_retriever)
+                out = _add_secondary_if_exists([x + ".fai", os.path.splitext(x)[0] + ".dict", os.path.splitext(x)[0] + "-resources.yaml"], out, get_retriever)
             elif x.endswith(".fa.gz"):
                 out = _add_secondary_if_exists([x + ".fai", x + ".gzi", x.replace(".fa.gz", "") + ".dict"],
                                                out, get_retriever)


### PR DESCRIPTION
resources.yaml is required to be included as secondary files in order to run the postprocess_alignment_to_rec and prep_samples_to_rec steps