### PR TITLE
Add option to preserve test output dir between test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.idx
 *.swo
 *.swp
+**/bcbiotx/
 bcbio/pipeline/version.py
 bcbio_nextgen.egg-info/
 build/
@@ -16,7 +17,6 @@ tests/data/110907*
 tests/data/genomes*
 tests/data/reference_material/7_100326_FC6107FAAXX-grade.vcf.gz*
 tests/data/tcga_benchmark
-tests/test_automated_output/
 tests/data/automated/config/
 tests/data/automated/galaxy/
 tests/data/automated/gemini_data/

--- a/docs/contents/development.md
+++ b/docs/contents/development.md
@@ -141,6 +141,8 @@ To see the test coverage, add the `--cov=bcbio` argument to `py.test`.
 
 By default the test suite will use your installed system configuration for running tests, substituting the test genome information instead of using full genomes. If you need a specific testing environment, copy `tests/data/automated/post_process-sample.yaml` to `tests/data/automated/post_process.yaml` to provide a test-only configuration.
 
+Note: work directory is preserved between test runs. To avoid reusing the output of a previous run delete `tests/test_automated_output` directory (or `$BCBIO_TEST_DIR/test_automated_output` in Vagrant).
+
 ## Adding tools
 
 ### Aligner

--- a/docs/contents/development.md
+++ b/docs/contents/development.md
@@ -141,8 +141,6 @@ To see the test coverage, add the `--cov=bcbio` argument to `pytest`.
 
 By default the test suite will use your installed system configuration for running tests, substituting the test genome information instead of using full genomes. If you need a specific testing environment, copy `tests/data/automated/post_process-sample.yaml` to `tests/data/automated/post_process.yaml` to provide a test-only configuration.
 
-Note: work directory is preserved between test runs. To avoid reusing the output of a previous run delete `tests/test_automated_output` directory (or `$BCBIO_TEST_DIR/test_automated_output` in Vagrant).
-
 ## Adding tools
 
 ### Aligner

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -14,6 +14,3 @@ set -e -x
 
 NEW_PATH='${HOME}/local/share/bcbio/anaconda/bin:${HOME}/local/bin:${PATH}'
 /bin/grep -qxF "PATH=${NEW_PATH}" ~vagrant/.profile || /bin/echo "PATH=${NEW_PATH}" >> ~vagrant/.profile
-# configure test directory within the internal VM file system because synced folders do not support certain features required by bcbio
-# for example: mkfifo is required for CWL Cromwell runs, etc
-/bin/grep -qxF 'export BCBIO_TEST_DIR=/tmp/bcbio' ~vagrant/.profile || /bin/echo 'export BCBIO_TEST_DIR=/tmp/bcbio' >> ~vagrant/.profile

--- a/tests/bcbio_vm/test_docker.py
+++ b/tests/bcbio_vm/test_docker.py
@@ -5,49 +5,33 @@ import subprocess
 import pytest
 
 from bcbio import utils
+from tests.conftest import install_cwl_test_files
 
-from tests.conftest import (make_workdir, get_post_process_yaml, install_cwl_test_files)
 
 @pytest.mark.docker
 @pytest.mark.docker_multicore
-def test_docker(install_test_files, data_dir):
-    """Run an analysis with code and tools inside a docker container.
-
+def test_docker(install_test_files, data_dir, global_config):
+    """Run an analysis with code and tools inside a docker container
     Requires https://github.com/bcbio/bcbio-nextgen-vm
     """
-    with make_workdir() as workdir:
-        cl = [
-            "bcbio_vm.py",
-            "--datadir=%s" % data_dir,
-            "run",
-            "--image=quay.io/bcbio/bcbio-vc",
-            "--systemconfig=%s" % get_post_process_yaml(data_dir, workdir),
-            "--fcdir=%s" % os.path.join(
-                data_dir, os.pardir, "100326_FC6107FAAXX"),
-            os.path.join(data_dir, "run_info-bam.yaml")
-        ]
-        subprocess.check_call(cl)
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-bam.yaml')
+    subprocess.check_call(['bcbio_vm.py', f'--datadir={data_dir}', 'run',
+                           '--image=quay.io/bcbio/bcbio-vc', f'--systemconfig={global_config}',
+                           f'--fcdir={fc_dir}', run_config])
+
 
 @pytest.mark.docker
 @pytest.mark.docker_ipython
-def test_docker_ipython(install_test_files, data_dir):
-    """Run an analysis with code and tools inside a docker container,
-    driven via IPython.
-
+def test_docker_ipython(install_test_files, data_dir, global_config):
+    """Run an analysis with code and tools inside a docker container, driven via IPython
     Requires https://github.com/bcbio/bcbio-nextgen-vm
     """
-    with make_workdir() as workdir:
-        cl = [
-            "bcbio_vm.py",
-            "--datadir=%s" % data_dir,
-            "ipython",
-            "--systemconfig=%s" % get_post_process_yaml(data_dir, workdir),
-            "--fcdir=%s" % os.path.join(
-                data_dir, os.pardir, "100326_FC6107FAAXX"),
-            os.path.join(data_dir, "run_info-bam.yaml"),
-            "lsf", "localrun"
-        ]
-        subprocess.check_call(cl)
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-bam.yaml')
+    subprocess.check_call(['bcbio_vm.py', f'--datadir={data_dir}', 'ipython',
+                           f'--systemconfig={global_config}', f'--fcdir={fc_dir}', run_config,
+                           'lsf', 'localrun'])
 
 
 class TestCWL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,20 +36,13 @@ def data_dir():
 
 @contextlib.contextmanager
 def make_workdir():
-    # set to False if you don't want to remove the current testing directory
-    remove_old_dir = True
-
     custom_test_dir = os.getenv("BCBIO_TEST_DIR")
-
     if custom_test_dir:
         work_dir = os.path.join(custom_test_dir, os.path.basename(default_workdir()))
     else:
         work_dir = default_workdir()
 
-    if remove_old_dir and os.path.exists(work_dir):
-        shutil.rmtree(work_dir)
-    if not os.path.exists(work_dir):
-        os.makedirs(work_dir)
+    os.makedirs(work_dir, exist_ok=True)
 
     # workaround for hardcoded data file paths in test run config files
     if custom_test_dir:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,10 +155,9 @@ def install_test_files(data_dir):
         if not os.path.exists(dirname):
             _download_to_dir(url, dirname)
 
+
 def _download_to_dir(url, dirname):
-        cl = ["wget", url]
-        subprocess.check_call(cl)
-        cl = ["tar", "-xzvpf", os.path.basename(url)]
-        subprocess.check_call(cl)
-        shutil.move(os.path.basename(dirname), dirname)
-        os.remove(os.path.basename(url))
+    subprocess.check_call(['wget', '--progress=dot:giga', url])
+    subprocess.check_call(['tar', '-xzvpf', os.path.basename(url)])
+    shutil.move(os.path.basename(dirname), dirname)
+    os.remove(os.path.basename(url))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,16 +20,19 @@ BCBIO_TEST_DIR = os.path.join(tempfile.gettempdir(), 'bcbio')  # /tmp/bcbio
 
 
 def pytest_addoption(parser):
-    parser.addoption('--keep-work-dir', action='store_true', default=False,
+    parser.addoption('--keep-test-dir', action='store_true', default=False,
                      help='Preserve test output directory after each test')
 
 
-@pytest.fixture
-def test_dir():
+@pytest.fixture(scope='session')
+def test_dir(pytestconfig):
     os.makedirs(BCBIO_TEST_DIR, exist_ok=True)
+    yield
+    if not pytestconfig.getoption('--keep-test-dir'):
+        shutil.rmtree(BCBIO_TEST_DIR)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def data_dir(test_dir):
     # workaround for hardcoded data file paths in test run config files
     test_data_dir = os.path.join(BCBIO_TEST_DIR, 'data')  # /tmp/bcbio/data
@@ -47,7 +50,7 @@ def work_dir(pytestconfig):
     os.chdir(test_output_dir)
     yield test_output_dir
     os.chdir(original_dir)
-    if not pytestconfig.getoption('--keep-work-dir'):
+    if not pytestconfig.getoption('--keep-test-dir'):
         shutil.rmtree(test_output_dir)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ import yaml
 
 from bcbio.pipeline.config_utils import load_system_config
 
-BCBIO_TEST_DIR = os.path.join(tempfile.gettempdir(), 'bcbio')
-SOURCE_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+BCBIO_TEST_DIR = os.path.join(tempfile.gettempdir(), 'bcbio')  # /tmp/bcbio
+BCBIO_TEST_DATA_DIR = os.path.join(BCBIO_TEST_DIR, 'data')  # /tmp/bcbio/data
 
 
 def pytest_addoption(parser):
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def data_dir():
-    return os.path.join(SOURCE_DATA_DIR, 'automated')
+    return os.path.join(BCBIO_TEST_DATA_DIR, 'automated')  # /tmp/bcbio/data/automated
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def work_dir(pytestconfig):
 
     # workaround for hardcoded data file paths in test run config files
     with contextlib.suppress(FileExistsError):
-        os.symlink(SOURCE_DATA_DIR, os.path.join(BCBIO_TEST_DIR, 'data'))
+        os.symlink(os.path.join(os.path.dirname(__file__), 'data'), BCBIO_TEST_DATA_DIR)
 
     original_dir = os.getcwd()
     os.chdir(test_output_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,4 @@
-"""Pytest fixtures and test helper functions
-
-BCBIO_TEST_DIR environment variable is used to run tests in a directory outside of the source tree
-In Vagrant it must point to a directory outside of a synced_folder for integration tests to pass
-For example: export BCBIO_TEST_DIR=/tmp/bcbio
-"""
+"""Pytest fixtures and test helper functions"""
 
 import collections
 import contextlib
@@ -13,6 +8,7 @@ import os
 import shutil
 import subprocess
 import tarfile
+import tempfile
 
 import pytest
 import requests
@@ -20,50 +16,44 @@ import yaml
 
 from bcbio.pipeline.config_utils import load_system_config
 
+BCBIO_TEST_DIR = os.path.join(tempfile.gettempdir(), 'bcbio')
+SOURCE_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
-def default_workdir():
-    return os.path.join(os.path.dirname(__file__), "test_automated_output")
 
-
-def test_data_dir():
-    return os.path.join(os.path.dirname(__file__), "data")
+def pytest_addoption(parser):
+    parser.addoption('--keep-work-dir', action='store_true', default=False,
+                     help='Preserve test output directory after each test')
 
 
 @pytest.fixture
 def data_dir():
-    return os.path.join(test_data_dir(), "automated")
+    return os.path.join(SOURCE_DATA_DIR, 'automated')
 
 
-@contextlib.contextmanager
-def make_workdir():
-    custom_test_dir = os.getenv("BCBIO_TEST_DIR")
-    if custom_test_dir:
-        work_dir = os.path.join(custom_test_dir, os.path.basename(default_workdir()))
-    else:
-        work_dir = default_workdir()
-
-    os.makedirs(work_dir, exist_ok=True)
+@pytest.fixture
+def work_dir(pytestconfig):
+    """Provide and manage output directory for tests"""
+    test_output_dir = os.path.join(BCBIO_TEST_DIR, 'test_automated_output')
+    os.makedirs(test_output_dir, exist_ok=True)
 
     # workaround for hardcoded data file paths in test run config files
-    if custom_test_dir:
-        custom_test_data_dir = os.path.join(custom_test_dir, os.path.basename(test_data_dir()))
-        with contextlib.suppress(FileExistsError):
-            os.symlink(test_data_dir(), custom_test_data_dir)
+    with contextlib.suppress(FileExistsError):
+        os.symlink(SOURCE_DATA_DIR, os.path.join(BCBIO_TEST_DIR, 'data'))
 
-    orig_dir = os.getcwd()
-    try:
-        os.chdir(work_dir)
-        yield work_dir
-    finally:
-        os.chdir(orig_dir)
+    original_dir = os.getcwd()
+    os.chdir(test_output_dir)
+    yield test_output_dir
+    os.chdir(original_dir)
+    if not pytestconfig.getoption('--keep-work-dir'):
+        shutil.rmtree(test_output_dir)
 
 
-def get_post_process_yaml(data_dir, workdir):
-    """Prepare a bcbio_system YAML file pointing to test data.
-    """
-    system = _get_bcbio_system(workdir, data_dir)
+@pytest.fixture
+def global_config(data_dir, work_dir):
+    """Prepare a bcbio_system YAML file pointing to test data"""
+    system = _get_bcbio_system(work_dir, data_dir)
     # create local config pointing to reduced genomes
-    test_system = os.path.join(workdir, "bcbio_system.yaml")
+    test_system = os.path.join(work_dir, 'bcbio_system.yaml')
     with open(system) as in_handle:
         config = yaml.safe_load(in_handle)
         config["galaxy_config"] = os.path.join(data_dir, "universe_wsgi.ini")
@@ -76,8 +66,7 @@ def get_post_process_yaml(data_dir, workdir):
 def install_cwl_test_files():
     orig_dir = os.getcwd()
     url = "https://github.com/bcbio/test_bcbio_cwl/archive/master.tar.gz"
-    test_dir = os.getenv("BCBIO_TEST_DIR", test_data_dir())
-    dirname = os.path.join(test_dir, "test_bcbio_cwl-master")
+    dirname = os.path.join(BCBIO_TEST_DIR, 'test_bcbio_cwl-master')
     if os.path.exists(dirname):
         # check for updated commits if the directory exists
         ctime = os.path.getctime(os.path.join(dirname, "README.md"))

--- a/tests/integration/rnaseq/test_ericscript.py
+++ b/tests/integration/rnaseq/test_ericscript.py
@@ -6,7 +6,6 @@ import pytest
 import pandas as pd
 
 from bcbio.rnaseq import ericscript
-from tests.conftest import make_workdir
 from bcbio.pipeline import config_utils, run_info
 from bcbio.log import setup_script_logging
 
@@ -30,30 +29,26 @@ def setup_logging():
 @pytest.mark.install_required
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3219', run=False)
 def test_detect_fusions_with_ericscipt_without_disambiguate(
-        install_test_files, data_dir, setup_logging):
+        install_test_files, data_dir, work_dir, setup_logging):
     """Run gene fusion analysis on trimmed pair-end reads with EricScript.
        Requires installation of EricScript and its reference data.
     """
-    with make_workdir() as work_dir:
-        sample_config = create_sample_config(
-            data_dir, work_dir, disambiguate=False)
-        ericscript.run(sample_config)
-        assert_run_successfully(work_dir=work_dir, data_dir=data_dir)
+    sample_config = create_sample_config(data_dir, work_dir, disambiguate=False)
+    ericscript.run(sample_config)
+    assert_run_successfully(work_dir=work_dir, data_dir=data_dir)
 
 
 @pytest.mark.ericscript
 @pytest.mark.install_required
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3220', run=False)
 def test_detect_fusions_with_ericscipt_with_disambiguate(
-        install_test_files, data_dir, setup_logging):
+        install_test_files, data_dir, work_dir, setup_logging):
     """Run gene fusion analysis on disambiguated reads with EricScript.
        Requires installation of EricScript and its reference data.
     """
-    with make_workdir() as work_dir:
-        sample_config = create_sample_config(
-            data_dir, work_dir, disambiguate=True)
-        ericscript.run(sample_config)
-        assert_run_successfully(work_dir=work_dir, data_dir=data_dir)
+    sample_config = create_sample_config(data_dir, work_dir, disambiguate=True)
+    ericscript.run(sample_config)
+    assert_run_successfully(work_dir=work_dir, data_dir=data_dir)
 
 
 class ConfigCreator(object):

--- a/tests/integration/test_S3_pipelines.py
+++ b/tests/integration/test_S3_pipelines.py
@@ -2,50 +2,39 @@ import os
 import subprocess
 
 import pytest
-from tests.conftest import make_workdir
-from tests.conftest import get_post_process_yaml
 
 
 @pytest.mark.S3
 @pytest.mark.install_required
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3216', run=False)
-def test_fusion(install_test_files, data_dir):
+def test_fusion(install_test_files, data_dir, global_config):
     """Run an RNA-seq analysis and test fusion genes, with human-mouse disambiguation.
     Requires minikraken database.
     """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_fusion"),
-              os.path.join(data_dir, "run_info-fusion_S3.yaml")]
-        subprocess.check_call(cl)
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_fusion')
+    run_config = os.path.join(data_dir, 'run_info-fusion_S3.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.S3
 @pytest.mark.install_required
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3217', run=False)
-def test_variantcall_1(install_test_files, data_dir):
+def test_variantcall_1(install_test_files, data_dir, global_config):
     """Test variant calling with disambiguation.
     Requires minikraken database.
     """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX"),
-              os.path.join(data_dir, "run_info-variantcall_S3_1.yaml")]
-        subprocess.check_call(cl)
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-variantcall_S3_1.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.S3
 @pytest.mark.install_required
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3218', run=False)
-def test_variantcall_2(install_test_files, data_dir):
+def test_variantcall_2(install_test_files, data_dir, global_config):
     """Test variant calling with disambiguation.
     Requires minikraken database.
     """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX"),
-              os.path.join(data_dir, "run_info-variantcall_S3_2.yaml")]
-        subprocess.check_call(cl)
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-variantcall_S3_2.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])

--- a/tests/integration/test_automated_analysis.py
+++ b/tests/integration/test_automated_analysis.py
@@ -11,47 +11,32 @@ import subprocess
 
 import pytest
 
-from tests.conftest import get_post_process_yaml, make_workdir
+
+@pytest.mark.speed3
+@pytest.mark.xfail(reason='Multiplexing not supporting in latest versions', run=False)
+def test_full_pipeline_with_multiplexing(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '110106_FC70BUKAAXX')
+    run_config = os.path.join(data_dir, 'run_info.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.speed3
-@pytest.mark.skip(reason='Multiplexing not supporting in latest versions')
-def test_3_full_pipeline(install_test_files, data_dir):
-    """Run full automated analysis pipeline with multiplexing.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "110106_FC70BUKAAXX"),
-              os.path.join(data_dir, "run_info.yaml")]
-        subprocess.check_call(cl)
+@pytest.mark.xfail(reason='Multiplexing not supporting in latest versions', run=False)
+def test_handle_empty_fastq_inputs_from_failed_runs(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '110221_empty_FC12345AAXX')
+    run_config = os.path.join(data_dir, 'run_info-empty.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
-@pytest.mark.skip(reason='Multiplexing not supporting in latest versions')
-@pytest.mark.speed3
-def test_4_empty_fastq(install_test_files, data_dir):
-    """Handle analysis of empty fastq inputs from failed runs.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "110221_empty_FC12345AAXX"),
-              os.path.join(data_dir, "run_info-empty.yaml")]
-        subprocess.check_call(cl)
-
-
+@pytest.mark.speed1
 @pytest.mark.rnaseq
 @pytest.mark.stranded
 @pytest.mark.install_required
-def test_2_stranded(install_test_files, data_dir):
-    """Run an RNA-seq analysis with TopHat and generate gene-level counts.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_stranded"),
-              os.path.join(data_dir, "run_info-stranded.yaml")]
-        subprocess.check_call(cl)
+def test_stranded(install_test_files, data_dir, global_config):
+    """Run an RNA-seq analysis with TopHat and generate gene-level counts"""
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_stranded')
+    run_config = os.path.join(data_dir, 'run_info-stranded.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.rnaseq
@@ -59,275 +44,181 @@ def test_2_stranded(install_test_files, data_dir):
 @pytest.mark.rnaseq_vc
 @pytest.mark.install_required
 @pytest.mark.skip(reason="tophat is no longer supported.")
-def test_2_rnaseq(install_test_files, data_dir):
-    """Run an RNA-seq analysis with TopHat and generate gene-level counts.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "110907_ERP000591"),
-              os.path.join(data_dir, "run_info-rnaseq.yaml")]
-        subprocess.check_call(cl)
+def test_rnaseq_with_tophat(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '110907_ERP000591')
+    run_config = os.path.join(data_dir, 'run_info-rnaseq.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.fusion
-def test_2_fusion(install_test_files, data_dir):
-    """Run an RNA-seq analysis and test fusion genes
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_fusion"),
-              os.path.join(data_dir, "run_info-fusion.yaml")]
-        subprocess.check_call(cl)
+def test_rnaseq_fusion_genes(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_fusion')
+    run_config = os.path.join(data_dir, 'run_info-fusion.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.star
 @pytest.mark.rnaseq
 @pytest.mark.rnaseq_standard
-def test_2_star(install_test_files, data_dir):
-    """Run an RNA-seq analysis with STAR and generate gene-level counts.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_fusion"),
-              os.path.join(data_dir, "run_info-star.yaml")]
-        subprocess.check_call(cl)
+def test_rnaseq_with_star(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_fusion')
+    run_config = os.path.join(data_dir, 'run_info-star.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.fastrnaseq
 @pytest.mark.rnaseq
-def test_2_fastrnaseq(install_test_files, data_dir):
-    """Run a fast RNA-seq analysis
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_fusion"),
-              os.path.join(data_dir, "run_info-fastrnaseq.yaml")]
-        subprocess.check_call(cl)
+def test_fast_rnaseq(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_fusion')
+    run_config = os.path.join(data_dir, 'run_info-fastrnaseq.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.rnaseq
 @pytest.mark.scrnaseq
-def test_2_scrnaseq(install_test_files, data_dir):
-    """Run a single-cell RNA-seq analysis
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "Harvard-inDrop"),
-              os.path.join(data_dir, "run_info-scrnaseq.yaml")]
-        subprocess.check_call(cl)
+def test_scrnaseq(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'Harvard-inDrop')
+    run_config = os.path.join(data_dir, 'run_info-scrnaseq.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.rnaseq
 @pytest.mark.rnaseq_standard
 @pytest.mark.hisat2
-def test_2_hisat2(install_test_files, data_dir):
-    """Run an RNA-seq analysis with hisat2 and generate gene-level counts.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "110907_ERP000591"),
-              os.path.join(data_dir, "run_info-hisat2.yaml")]
-        subprocess.check_call(cl)
+def test_rnaseq_with_hisat2(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '110907_ERP000591')
+    run_config = os.path.join(data_dir, 'run_info-hisat2.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.rnaseq
 @pytest.mark.singleend
 @pytest.mark.explant
-def test_explant(install_test_files, data_dir):
-    """
-    Run an explant RNA-seq analysis with TopHat
-    and generate gene-level counts.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "1_explant"),
-              os.path.join(data_dir, "run_info-explant.yaml")]
-        subprocess.check_call(cl)
+def test_explant_with_tophat(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '1_explant')
+    run_config = os.path.join(data_dir, 'run_info-explant.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.srnaseq
 @pytest.mark.srnaseq_star
-def test_srnaseq_star(install_test_files, data_dir):
-    """Run an sRNA-seq analysis.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_srnaseq"),
-              os.path.join(data_dir, "run_info-srnaseq_star.yaml")]
-        subprocess.check_call(cl)
+def test_srnaseq_star(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_srnaseq')
+    run_config = os.path.join(data_dir, 'run_info-srnaseq_star.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.srnaseq
 @pytest.mark.srnaseq_bowtie
-def test_srnaseq_bowtie(install_test_files, data_dir):
-    """Run an sRNA-seq analysis.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_srnaseq"),
-              os.path.join(data_dir, "run_info-srnaseq_bowtie.yaml")]
-        subprocess.check_call(cl)
+def test_srnaseq_bowtie(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_srnaseq')
+    run_config = os.path.join(data_dir, 'run_info-srnaseq_bowtie.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.chipseq
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3224', run=False)
-def test_chipseq(install_test_files, data_dir):
-    """Run a chip-seq alignment with Bowtie2"""
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_chipseq"),
-              os.path.join(data_dir, "run_info-chipseq.yaml")]
-        subprocess.check_call(cl)
+def test_chipseq_with_bowtie2(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_chipseq')
+    run_config = os.path.join(data_dir, 'run_info-chipseq.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.atacseq
 @pytest.mark.xfail(reason='https://github.com/bcbio/bcbio-nextgen/issues/3225', run=False)
-def test_atacseq(install_test_files, data_dir):
-    """Test ATAC-seq pipeline"""
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "test_atacseq"),
-              os.path.join(data_dir, "run_info-atacseq.yaml")]
-        subprocess.check_call(cl)
+def test_atacseq(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, 'test_atacseq')
+    run_config = os.path.join(data_dir, 'run_info-atacseq.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.speed1
 @pytest.mark.ensemble
 @pytest.mark.install_required
-def test_1_variantcall(install_test_files, data_dir):
-    """Test variant calling with GATK pipeline.
-    Requires GATK.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX"),
-              os.path.join(data_dir, "run_info-variantcall.yaml")]
-        subprocess.check_call(cl)
+def test_variant_call_gatk(install_test_files, global_config, data_dir):
+    # requires GATK
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-variantcall.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.devel
 @pytest.mark.speed1
-def test_variant2_pipeline_with_bam_input(install_test_files, data_dir):
-    with make_workdir() as workdir:
-        global_config = get_post_process_yaml(data_dir, workdir)
-        run_config = os.path.join(data_dir, "run_info-bam.yaml")
-        subprocess.check_call(["bcbio_nextgen.py", global_config, run_config])
+def test_variant2_pipeline_with_bam_input(install_test_files, global_config, data_dir):
+    run_config = os.path.join(data_dir, 'run_info-bam.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
 
 
 @pytest.mark.speed2
 @pytest.mark.install_required
-def test_6_bamclean(install_test_files, data_dir):
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX"),
-              os.path.join(data_dir, "run_info-bamclean.yaml")]
-        subprocess.check_call(cl)
+def test_bamclean(install_test_files, data_dir, global_config):
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    run_config = os.path.join(data_dir, 'run_info-bamclean.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, fc_dir, run_config])
 
 
 @pytest.mark.speed2
 @pytest.mark.cancer
 @pytest.mark.cancermulti
 @pytest.mark.install_required
-def test_7_cancer(install_test_files, data_dir):
-    """Test paired tumor-normal calling using multiple
-    calling approaches: MuTect, VarScan, FreeBayes.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, "run_info-cancer.yaml")]
-        subprocess.check_call(cl)
+def test_paired_tumornormal_calling(install_test_files, data_dir, global_config):
+    # using MuTect, VarScan, FreeBayes
+    run_config = os.path.join(data_dir, 'run_info-cancer.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
 
 
 @pytest.mark.cancer
 @pytest.mark.cancerpanel
 @pytest.mark.install_required
-def test_7_cancer_nonormal(install_test_files, data_dir):
-    """Test cancer calling without normal samples or with normal VCF panels.
-    Requires MuTect and GATK.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, "run_info-cancer2.yaml")]
-        subprocess.check_call(cl)
+def test_cancer_calling_with_and_without_normal(install_test_files, data_dir, global_config):
+    # requires MuTect and GATK
+    run_config = os.path.join(data_dir, 'run_info-cancer2.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
+
 
 @pytest.mark.cancer
 @pytest.mark.cancerprecall
 @pytest.mark.install_required
-def test_7b_cancer_precall(install_test_files, data_dir):
-    """Test somatic prioritization and effects prediction with pre-called inputs.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, "run_info-cancer3.yaml")]
-        subprocess.check_call(cl)
+def test_cancer_with_precalled_inputs(install_test_files, data_dir, global_config):
+    run_config = os.path.join(data_dir, 'run_info-cancer3.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
+
 
 @pytest.mark.speed1
 @pytest.mark.template
-def test_8_template(install_test_files, data_dir):
-    """Create a project template from input files and metadata configuration.
-    """
-    fc_dir = os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX")
-    with make_workdir():
-        cl = ["bcbio_nextgen.py", "-w", "template", "--only-metadata",
-              "freebayes-variant",
-              os.path.join(fc_dir, "100326.csv"),
-              os.path.join(fc_dir, "7_100326_FC6107FAAXX_1_fastq.txt"),
-              os.path.join(fc_dir, "7_100326_FC6107FAAXX_2_fastq.txt"),
-              os.path.join(fc_dir, "8_100326_FC6107FAAXX.bam")]
-        subprocess.check_call(cl)
+def test_create_project_template(install_test_files, data_dir, work_dir):
+    fc_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX')
+    subprocess.check_call(['bcbio_nextgen.py', '-w', 'template', '--only-metadata',
+                           'freebayes-variant', os.path.join(fc_dir, '100326.csv'),
+                           os.path.join(fc_dir, '7_100326_FC6107FAAXX_1_fastq.txt'),
+                           os.path.join(fc_dir, '7_100326_FC6107FAAXX_2_fastq.txt'),
+                           os.path.join(fc_dir, '8_100326_FC6107FAAXX.bam')])
 
 
 @pytest.mark.joint
 @pytest.mark.install_required
-def test_9_joint(install_test_files, data_dir):
-    """Perform joint calling/backfilling/squaring off following variant calling.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, "run_info-joint.yaml")]
-        subprocess.check_call(cl)
+def test_joint_calling(install_test_files, data_dir, global_config):
+    run_config = os.path.join(data_dir, 'run_info-joint.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
+
 
 @pytest.mark.umibarcode
 @pytest.mark.install_required
-def test_10_umi(install_test_files, data_dir):
-    """Allow BAM files as input to pipeline.
-    """
-    with make_workdir() as workdir:
-        cl = ["bcbio_nextgen.py",
-              get_post_process_yaml(data_dir, workdir),
-              os.path.join(data_dir, "run_info-umi.yaml")]
-        subprocess.check_call(cl)
+def test_umi_with_bam_inputs(install_test_files, data_dir, global_config):
+    run_config = os.path.join(data_dir, 'run_info-umi.yaml')
+    subprocess.check_call(['bcbio_nextgen.py', global_config, run_config])
+
 
 @pytest.mark.hla
-def test_11_hla(install_test_files, data_dir):
-    """Test HLA typing with OptiType.
-    """
+def test_hla_typing_with_optitype(install_test_files, data_dir, work_dir):
     from bcbio.hla import optitype
-    hla_dir = os.path.join(data_dir, os.pardir, "100326_FC6107FAAXX", "hla")
-    with make_workdir() as workdir:
-        data = {"dirs": {"work": workdir},
-                "rgnames": {"sample": "test"},
-                "config": {},
-                "hla": {"fastq": glob.glob(os.path.join(hla_dir, "*"))}}
-        out = optitype.run(data)
-        with open(out["hla"]["call_file"]) as in_handle:
-            header = in_handle.readline().strip().split(",")
-            hla_a = dict(zip(header, in_handle.readline().strip().split(",")))
-            assert hla_a["alleles"] == "HLA-A*11:01;HLA-A*24:02", hla_a
+    hla_dir = os.path.join(data_dir, os.pardir, '100326_FC6107FAAXX', 'hla')
+    data = {"dirs": {"work": work_dir},
+            "rgnames": {"sample": "test"},
+            "config": {},
+            "hla": {"fastq": glob.glob(os.path.join(hla_dir, "*"))}}
+    out = optitype.run(data)
+    with open(out["hla"]["call_file"]) as in_handle:
+        header = in_handle.readline().strip().split(",")
+        hla_a = dict(zip(header, in_handle.readline().strip().split(",")))
+        assert hla_a["alleles"] == "HLA-A*11:01;HLA-A*24:02", hla_a

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,7 +1,5 @@
-"""Test individual components of the analysis pipeline.
-"""
+"""Test individual components of the analysis pipeline"""
 import os
-import sys
 import shutil
 import subprocess
 
@@ -10,20 +8,17 @@ from bcbio.bam import fastq
 from bcbio.distributed import prun
 from bcbio.pipeline.config_utils import load_config
 
-from tests.conftest import make_workdir, get_post_process_yaml
-
 import pytest
+
 
 class TestRunInfo(object):
 
     @pytest.mark.speed1
-    def test_programs(self, data_dir):
+    def test_programs(self, global_config):
         """Identify programs and versions used in analysis.
         """
         from bcbio.provenance import programs
-        with make_workdir() as workdir:
-            config = load_config(get_post_process_yaml(data_dir, workdir))
-            print(programs._get_versions(config))
+        print(programs._get_versions(load_config(global_config)))
 
 
 class TestVCFUtil(object):
@@ -35,10 +30,6 @@ class TestVCFUtil(object):
             os.path.dirname(os.path.dirname(__file__)),
             "data"
         )
-
-    @property
-    def automated_dir(self):
-        return os.path.join(self.data_dir, "automated")
 
     @property
     def var_dir(self):
@@ -54,7 +45,7 @@ class TestVCFUtil(object):
 
     @pytest.mark.speed1
     @pytest.mark.combo
-    def test_1_parallel_vcf_combine(self):
+    def test_1_parallel_vcf_combine(self, global_config):
         """Parallel combination of VCF files, split by chromosome.
         """
         from bcbio.variation import vcfutils
@@ -62,10 +53,8 @@ class TestVCFUtil(object):
             os.path.join(self.var_dir, "S1-variants.vcf"),
             os.path.join(self.var_dir, "S2-variants.vcf")
         ]
-        with make_workdir() as workdir:
-            config = load_config(
-                get_post_process_yaml(self.automated_dir, workdir))
-            config["algorithm"] = {}
+        config = load_config(global_config)
+        config["algorithm"] = {}
         region_dir = os.path.join(self.var_dir, "S1_S2-combined-regions")
         if os.path.exists(region_dir):
             shutil.rmtree(region_dir)
@@ -83,14 +72,12 @@ class TestVCFUtil(object):
 
     @pytest.mark.speed1
     @pytest.mark.combo
-    def test_2_vcf_exclusion(self):
+    def test_2_vcf_exclusion(self, global_config):
         """Exclude samples from VCF files.
         """
         from bcbio.variation import vcfutils
-        with make_workdir() as workdir:
-            config = load_config(
-                get_post_process_yaml(self.automated_dir, workdir))
-            config["algorithm"] = {}
+        config = load_config(global_config)
+        config["algorithm"] = {}
         out_file = utils.append_stem(self.combo_file, "-exclude")
         to_exclude = ["S1"]
         if os.path.exists(out_file):
@@ -100,14 +87,12 @@ class TestVCFUtil(object):
 
     @pytest.mark.speed1
     @pytest.mark.combo
-    def test_3_vcf_split_combine(self):
+    def test_3_vcf_split_combine(self, global_config):
         """Split a VCF file into SNPs and indels, then combine back together.
         """
         from bcbio.variation import vcfutils
-        with make_workdir() as workdir:
-            config = load_config(get_post_process_yaml(
-                self.automated_dir, workdir))
-            config["algorithm"] = {}
+        config = load_config(global_config)
+        config["algorithm"] = {}
         fname = os.path.join(self.var_dir, "S1-variants.vcf")
         snp_file, indel_file = vcfutils.split_snps_indels(
             fname, self.ref_file, config)


### PR DESCRIPTION
Add `--keep-test-dir` option to close #3155. Simplify test configuration. Move test output directory outside the source tree.
