### PR TITLE
SCRAMble integration

### DIFF
--- a/bcbio/structural/__init__.py
+++ b/bcbio/structural/__init__.py
@@ -12,7 +12,7 @@ from bcbio.cwl import cwlutils
 from bcbio.pipeline import datadict as dd
 from bcbio.structural import (battenberg, cn_mops, cnvkit, delly, gatkcnv, gridss,
                               lumpy, manta, metasv, prioritize, purecn, purple, plot,
-                              seq2c, titancna, validate, wham)
+                              scramble, seq2c, titancna, validate, wham)
 from bcbio.variation import validate as vcvalidate
 from bcbio.variation import vcfutils
 
@@ -27,7 +27,7 @@ _CALLERS = {
                "delly": delly.run, "lumpy": lumpy.run, "wham": wham.run,
                "battenberg": battenberg.run, "seq2c": seq2c.run, "gridss": gridss.run,
                "titancna": titancna.run, "purecn": purecn.run, "purple": purple.run,
-               "gatk-cnv": gatkcnv.run},
+               "gatk-cnv": gatkcnv.run, "scramble": scramble.run},
   "ensemble": {"metasv": metasv.run,
                "prioritize": prioritize.run}}
 _NEEDS_BACKGROUND = set(["cn.mops"])

--- a/bcbio/structural/scramble.py
+++ b/bcbio/structural/scramble.py
@@ -12,11 +12,14 @@ from bcbio.provenance import do
 
 
 def run(items):
-    data = items[0]
-    input_bam_file_path = dd.get_work_bam(data)
-    work_dir = os.path.join(dd.get_work_dir(data), 'structural', dd.get_sample_name(data))
-    output_clusters_file_path = os.path.join(work_dir, 'clusters.txt')
-    if not utils.file_exists(output_clusters_file_path):
-        with file_transaction(output_clusters_file_path) as temp_output_file_path:
-            do.run(f'cluster_identifier {input_bam_file_path} > {temp_output_file_path}')
+    for index, data in enumerate(items):
+        work_dir = os.path.join(dd.get_work_dir(data), 'structural', dd.get_sample_name(data))
+        output_clusters_file_path = os.path.join(work_dir, 'clusters.txt')
+
+        if not utils.file_exists(output_clusters_file_path):
+            with file_transaction(output_clusters_file_path) as temp_output_file_path:
+                do.run(f'cluster_identifier {dd.get_work_bam(data)} > {temp_output_file_path}')
+
+        items[index].get('sv', []).append({'variantcaller': 'scramble',
+                                           'clusters_file': output_clusters_file_path})
     return items

--- a/bcbio/structural/scramble.py
+++ b/bcbio/structural/scramble.py
@@ -3,7 +3,20 @@
 https://github.com/GeneDx/scramble
 https://doi.org/10.1038/s41436-020-0749-x
 """
+import os
+
+from bcbio import utils
+from bcbio.distributed.transaction import file_transaction
+from bcbio.pipeline import datadict as dd
+from bcbio.provenance import do
 
 
 def run(items):
+    data = items[0]
+    input_bam_file_path = dd.get_work_bam(data)
+    work_dir = os.path.join(dd.get_work_dir(data), 'structural', dd.get_sample_name(data))
+    output_clusters_file_path = os.path.join(work_dir, 'clusters.txt')
+    if not utils.file_exists(output_clusters_file_path):
+        with file_transaction(output_clusters_file_path) as temp_output_file_path:
+            do.run(f'cluster_identifier {input_bam_file_path} > {temp_output_file_path}')
     return items

--- a/bcbio/structural/scramble.py
+++ b/bcbio/structural/scramble.py
@@ -1,0 +1,9 @@
+"""Mobile element insertion detection using SCRAMble (Soft Clipped Read Alignment Mapper)
+
+https://github.com/GeneDx/scramble
+https://doi.org/10.1038/s41436-020-0749-x
+"""
+
+
+def run(items):
+    return items

--- a/bcbio/structural/scramble.py
+++ b/bcbio/structural/scramble.py
@@ -21,16 +21,14 @@ def run(items):
                 do.run(f'cluster_identifier {dd.get_work_bam(data)} > {temp_output_file_path}',
                        'Running SCRAMble cluster_identifier')
 
-        output_mei_file_path = os.path.join(work_dir, 'mei.txt')
+        output_mei_file_path = os.path.join(work_dir, 'out_MEIs.txt')
         if not utils.file_exists(output_mei_file_path):
             with file_transaction(output_mei_file_path) as temp_mei_file_path:
-                # temp workaround: remove PREFIX when SCRAMble Conda package becomes available
-                PREFIX = '~/scramble/cluster_analysis'
-                do.run(f'{utils.Rscript_cmd()} --vanilla {PREFIX}/bin/SCRAMble-MEIs.R '
-                       f'--out-name {temp_mei_file_path} '
+                output_file_prefix = temp_mei_file_path.replace('_MEIs.txt', '', 1)
+                do.run(f'scramble.sh '
+                       f'--out-name {output_file_prefix} '
                        f'--cluster-file {output_clusters_file_path} '
-                       f'--install-dir {PREFIX}/bin '
-                       f'--mei-refs {PREFIX}/resources/MEI_consensus_seqs.fa',
+                       f'--eval-meis',
                        'Analyzing cluster file for likely MEIs')
 
         items[index].get('sv', []).append({'variantcaller': 'scramble',

--- a/bcbio/structural/scramble.py
+++ b/bcbio/structural/scramble.py
@@ -14,12 +14,26 @@ from bcbio.provenance import do
 def run(items):
     for index, data in enumerate(items):
         work_dir = os.path.join(dd.get_work_dir(data), 'structural', dd.get_sample_name(data))
-        output_clusters_file_path = os.path.join(work_dir, 'clusters.txt')
 
+        output_clusters_file_path = os.path.join(work_dir, 'clusters.txt')
         if not utils.file_exists(output_clusters_file_path):
             with file_transaction(output_clusters_file_path) as temp_output_file_path:
-                do.run(f'cluster_identifier {dd.get_work_bam(data)} > {temp_output_file_path}')
+                do.run(f'cluster_identifier {dd.get_work_bam(data)} > {temp_output_file_path}',
+                       'Running SCRAMble cluster_identifier')
+
+        output_mei_file_path = os.path.join(work_dir, 'mei.txt')
+        if not utils.file_exists(output_mei_file_path):
+            with file_transaction(output_mei_file_path) as temp_mei_file_path:
+                # temp workaround: remove PREFIX when SCRAMble Conda package becomes available
+                PREFIX = '~/scramble/cluster_analysis'
+                do.run(f'{utils.Rscript_cmd()} --vanilla {PREFIX}/bin/SCRAMble-MEIs.R '
+                       f'--out-name {temp_mei_file_path} '
+                       f'--cluster-file {output_clusters_file_path} '
+                       f'--install-dir {PREFIX}/bin '
+                       f'--mei-refs {PREFIX}/resources/MEI_consensus_seqs.fa',
+                       'Analyzing cluster file for likely MEIs')
 
         items[index].get('sv', []).append({'variantcaller': 'scramble',
-                                           'clusters_file': output_clusters_file_path})
+                                           'clusters_file': output_clusters_file_path,
+                                           'mei_file': output_mei_file_path})
     return items

--- a/bcbio/upload/__init__.py
+++ b/bcbio/upload/__init__.py
@@ -171,9 +171,9 @@ def _add_meta(xs, sample=None, config=None):
         out.append(x)
     return out
 
+
 def _get_files_variantcall(sample):
-    """Return output files for the variant calling pipeline.
-    """
+    """Return output files for the variant calling pipeline"""
     out = []
     algorithm = sample["config"]["algorithm"]
     out = _maybe_add_summary(algorithm, sample, out)
@@ -181,12 +181,13 @@ def _get_files_variantcall(sample):
     out = _maybe_add_callable(sample, out)
     out = _maybe_add_disambiguate(algorithm, sample, out)
     out = _maybe_add_variant_file(algorithm, sample, out)
-    out = _maybe_add_sv(algorithm, sample, out)
+    out = _maybe_add_sv(sample, out)
     out = _maybe_add_hla(algorithm, sample, out)
     out = _maybe_add_heterogeneity(algorithm, sample, out)
 
     out = _maybe_add_validate(algorithm, sample, out)
     return _add_meta(out, sample)
+
 
 def _maybe_add_validate(algorith, sample, out):
     for i, plot in enumerate(tz.get_in(("validate", "grading_plots"), sample, [])):
@@ -271,7 +272,8 @@ def _get_batch_name(sample):
         batch = dd.get_sample_name(sample)
     return batch
 
-def _maybe_add_sv(algorithm, sample, out):
+
+def _maybe_add_sv(sample, out):
     if sample.get("align_bam") is not None and sample.get("sv"):
         batch = _get_batch_name(sample)
         for svcall in sample["sv"]:
@@ -345,6 +347,7 @@ def _maybe_add_sv(algorithm, sample, out):
                                     "type": vext,
                                     "ext": "sv-validate%s" % ext})
     return out
+
 
 def _sample_variant_file_in_population(x):
     """Check if a sample file is the same as the population file.

--- a/bcbio/upload/__init__.py
+++ b/bcbio/upload/__init__.py
@@ -278,6 +278,10 @@ def _maybe_add_sv(algorithm, sample, out):
             if svcall.get("variantcaller") == "seq2c":
                 out.extend(_get_variant_file(svcall, ("calls",), sample=batch))
                 out.extend(_get_variant_file(svcall, ("gender_predicted",), sample=batch))
+            elif svcall.get('variantcaller') == 'scramble':
+                out.extend(_get_variant_file(svcall, ('clusters_file',), suffix='-clusters',
+                                             sample=batch))
+                out.extend(_get_variant_file(svcall, ('mei_file',), suffix='-mei', sample=batch))
             for key in ["vrn_file", "cnr", "cns", "seg", "gainloss",
                         "segmetrics", "vrn_bed", "vrn_bedpe"]:
                 out.extend(_get_variant_file(svcall, (key,), sample=batch))
@@ -832,7 +836,7 @@ def _get_files_project(sample, upload_config):
                 sv_project.add(svcall["calls_all"])
         if svcall.get("variantcaller") == "gatkcnv":
             if svcall.get("pon") and svcall["pon"] not in pon_project:
-                out.append({"path": svcall["pon"], "batch": "gatkcnv", "ext": "pon", "type": "hdf5"}) 
+                out.append({"path": svcall["pon"], "batch": "gatkcnv", "ext": "pon", "type": "hdf5"})
                 pon_project.add(svcall.get("pon"))
 
     if "coverage" in sample:


### PR DESCRIPTION
Toward #3244. This depends on https://github.com/chapmanb/cloudbiolinux/pull/369 and requires SCRAMble to be installed using Conda.

The following project config file was used for testing:
```
upload:
  dir: ../final
details:
  - algorithm:
      aligner: false
      bam_clean: remove_extracontigs
      svcaller: [scramble]
      variantcaller: false
    analysis: variant2
    description: test1
    files: [../input/test.bam]
    genome_build: hg38
  - algorithm:
      aligner: false
      bam_clean: remove_extracontigs
      svcaller: [scramble]
      variantcaller: false
    analysis: variant2
    description: test2
    files: [../input/test2.bam]
    genome_build: hg38
  - algorithm:
      aligner: false
      bam_clean: remove_extracontigs
      svcaller: [scramble]
      variantcaller: false
    analysis: variant2
    description: test3
    metadata:
      batch: batch1
    files: [../input/test3.bam]
    genome_build: hg38
  - algorithm:
      aligner: false
      bam_clean: remove_extracontigs
      svcaller: [scramble]
      variantcaller: false
    analysis: variant2
    description: test4
    metadata:
      batch: batch1
    files: [../input/test4.bam]
    genome_build: hg38
```

The BAM input file and validation results are from https://github.com/GeneDx/scramble/tree/af65422a79be48bbc455dbae8090e583d316be01/validation
