### PR TITLE
add tools_on: vardict_sv option

### DIFF
--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -50,10 +50,9 @@ def _vardict_options_from_config(items, config, out_file, target=None, is_rnaseq
     vardict_cl = get_vardict_command(items[0])
     version = programs.get_version_manifest(vardict_cl)
     # turn off structural variants
-    if (vardict_cl and version and
+    if ((vardict_cl and version and
         ((vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.5")) or
-         (vardict_cl == "vardict"))):
-         not vardict_sv_on):
+         (vardict_cl == "vardict"))) and not vardict_sv_on):
         opts += ["--nosv"]
     if (vardict_cl and version and
          (vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.6"))):

--- a/bcbio/variation/vardict.py
+++ b/bcbio/variation/vardict.py
@@ -44,12 +44,16 @@ def _vardict_options_from_config(items, config, out_file, target=None, is_rnaseq
     # Disable SV calling for vardict, causes issues with regional analysis
     # by detecting SVs outside of target regions, which messes up merging
     # SV calling will be worked on as a separate step
+    # use tools_on: vardict_sv to turn sv calling in vardict on (experimental)
+    tools_on = dd.get_in_samples(items, dd.get_tools_on)
+    vardict_sv_on = tools_on and "vardict_sv" in tools_on
     vardict_cl = get_vardict_command(items[0])
     version = programs.get_version_manifest(vardict_cl)
     # turn off structural variants
     if (vardict_cl and version and
         ((vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.5")) or
          (vardict_cl == "vardict"))):
+         not vardict_sv_on):
         opts += ["--nosv"]
     if (vardict_cl and version and
          (vardict_cl == "vardict-java" and LooseVersion(version) >= LooseVersion("1.5.6"))):

--- a/docs/contents/configuration.md
+++ b/docs/contents/configuration.md
@@ -401,6 +401,7 @@ bcbio provides some hints to change default behavior be either turning specific 
   * `vcf2db_expand` decompresses and expands the genotype columns in the vcfanno prepared GEMINI databases, enabling standard SQL queries on genotypes and depths.
   * `vqsr` makes GATK try quality score recalibration for variant filtration, even for smaller sample sizes.
   * `vep_splicesite_annotations` enables the use of the MaxEntScan and SpliceRegion plugin for VEP. Both optional plugins add extra splice site annotations.
+  * `vardict_sv` remove `--nosv` option from the vardict call (default is `--nosv` ON).
 
 ## Resources
 


### PR DESCRIPTION
this is an experimental feature: https://github.com/bcbio/bcbio-nextgen/issues/3384
allows to specify:
```
tools_on:
  vardict_sv
```
and remove --nosv option from the vardict call.

It may cause some issues in the output vcf. 
Reported to brake 
```
tools_on:
  damage_filter
```
