### PR TITLE
update default peak calling for antibody

### DIFF
--- a/bcbio/chipseq/macs2.py
+++ b/bcbio/chipseq/macs2.py
@@ -30,8 +30,10 @@ def run(name, chip_bam, input_bam, genome_build, out_dir, method, resources, dat
         antibody = antibody.lower()
         if antibody not in antibodies.SUPPORTED_ANTIBODIES:
             logger.error(f"{antibody} specified, but not listed as a supported antibody. Valid antibodies are {antibodies.SUPPORTED_ANTIBODIES}. If you know your antibody "
-                        f"should be called with narrow or broad peaks, supply 'narrow' or 'broad' as the antibody.")
-            sys.exit(1)
+                        f"should be called with narrow or broad peaks, supply 'narrow' or 'broad' as the antibody. 
+                        f"It will run 'narrow' if the antibody is not supported.")
+            antibody = 'narrow'
+            #sys.exit(1)
         antibody = antibodies.ANTIBODIES[antibody]
         logger.info(f"{antibody.name} specified, using {antibody.peaktype} peak settings.")
         peaksettings = select_peak_parameters(antibody)


### PR DESCRIPTION
Fixing the bug where the value of the `antibody` column is not within the list, no peaks are called.

**We want to run narrow peak calling (by default) if antibody is not recognized.**, as discussed with Shannan.

- Note that If there is no `antibody` column, narrowpeak call is called by default.