### PR TITLE
Allow choosing cloudbiolinux version

### DIFF
--- a/scripts/bcbio_nextgen_install.py
+++ b/scripts/bcbio_nextgen_install.py
@@ -294,6 +294,8 @@ if __name__ == "__main__":
                         choices=["stable", "development"], default="stable")
     parser.add_argument("--revision", help="Specify a git commit hash or tag to install",
                         default="master")
+    parser.add_argument("--cloudbiolinux", help="Specify a cloudbiolinux git commit hash or tag to install",
+                        default="master")
     parser.add_argument("--distribution", help="Operating system distribution", default="",
                         choices=["ubuntu", "debian", "centos", "scientificlinux", "macosx"])
     if len(sys.argv) == 1:

--- a/scripts/bcbio_setup_genome.py
+++ b/scripts/bcbio_setup_genome.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
  #       raise ValueError("--mirbase and --srna_gtf both need a value.")
 
     os.environ["PATH"] += os.pathsep + os.path.dirname(sys.executable)
-    cbl = get_cloudbiolinux(REMOTES)
+    cbl = get_cloudbiolinux(args, REMOTES)
     sys.path.insert(0, cbl["dir"])
     genomemod = __import__("cloudbio.biodata", fromlist=["genomes"])
     # monkey patch cloudbiolinux to use this indexing command instead


### PR DESCRIPTION
bcbio automatically installs cloudbiolinux, currently hardcoded as [the tip of its master branch](https://github.com/bcbio/bcbio-nextgen/commit/478cfc2675fa6107cb477f821cc42c51354c6ace).

This PR adds a new command-line argument `--cloudbiolinux` which allows optionally installing a different cloudbiolinux git commit hash or tag. This argument may be useful when cloudbiolinux master is WIP (such as https://github.com/chapmanb/cloudbiolinux/issues/386).