### PR TITLE
GATK: fix conda executable names

### DIFF
--- a/bcbio/broad/__init__.py
+++ b/bcbio/broad/__init__.py
@@ -175,7 +175,7 @@ class BroadRunner:
         Starting up GATK takes a lot of resources so we do it once at start of analysis.
         """
         out = []
-        for name in ["gatk", "gatk4", "picard", "mutect"]:
+        for name in ["gatk3", "gatk", "picard", "mutect"]:
             v = tz.get_in(["resources", name, "version"], config)
             if not v:
                 try:


### PR DESCRIPTION
`gatk` == gatk4 in conda, while the old `gatk` is replaced by `gatk3`. This results in faulty version detection