### PR TITLE
Bump pinned mamba version

### DIFF
--- a/scripts/bcbio_nextgen_install.py
+++ b/scripts/bcbio_nextgen_install.py
@@ -45,7 +45,7 @@ def main(args, sys_argv):
         print(f"Installing {conda_bin}")
         anaconda = install_mamba(anaconda, args)
         print("Installing conda-build")
-        subprocess.check_call([anaconda[conda_bin], "install", "--yes", "conda-build", "mamba=0.15.3"])
+        subprocess.check_call([anaconda[conda_bin], "install", "--yes", "conda-build", "mamba=0.24.0"])
         print("Installing bcbio-nextgen")
         bcbio = install_conda_pkgs(anaconda, args)
         bootstrap_bcbionextgen(anaconda, args)


### PR DESCRIPTION
conda 4.13.0 is now available and [breaks older versions of mamba](https://github.com/mamba-org/mamba/issues/1724).

I see https://github.com/bcbio/bcbio-nextgen/issues/3614 and commit https://github.com/bcbio/bcbio-nextgen/commit/960bcd1f0deb8de1062f93c50dd6de4d1d287b49 where the mamba version has been pinned.

This pull request simply bumps the mamba version to current 0.24.0. This tactic has succeeded in my environment.

