### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bcbio/ngsalign/bwa.py
+++ b/bcbio/ngsalign/bwa.py
@@ -105,7 +105,7 @@ def _get_bwa_mem_cmd(data, out_file, ref_file, fastq1, fastq2="", with_hla=False
     # For UMI runs, pass along consensus tags
     c_tags = "-C" if "umi_bam" in data else ""
     pairing = "-p" if not fastq2 else ""
-    # Restrict seed occurances to 1/2 of default, manage memory usage for centromere repeats in hg38
+    # Restrict seed occurrences to 1/2 of default, manage memory usage for centromere repeats in hg38
     # https://sourceforge.net/p/bio-bwa/mailman/message/31514937/
     # http://ehc.ac/p/bio-bwa/mailman/message/32268544/
     mem_usage = "-c 250"

--- a/bcbio/utils.py
+++ b/bcbio/utils.py
@@ -339,14 +339,14 @@ def file_plus_index(fname):
         return [fname]
 
 def remove_plus(orig):
-    """Remove a fils, including biological index files.
+    """Remove a file, including biological index files.
     """
     for ext in ["", ".idx", ".gbi", ".tbi", ".bai"]:
         if os.path.exists(orig + ext):
             remove_safe(orig + ext)
 
 def copy_plus(orig, new):
-    """Copy a fils, including biological index files.
+    """Copy a file, including biological index files.
     """
     for ext in ["", ".idx", ".gbi", ".tbi", ".bai"]:
         if os.path.exists(orig + ext) and (not os.path.lexists(new + ext) or not os.path.exists(new + ext)):

--- a/bcbio/variation/vcfutils.py
+++ b/bcbio/variation/vcfutils.py
@@ -205,7 +205,7 @@ def split_snps_indels(orig_file, ref_file, config):
     return snp_file, indel_file
 
 def get_normal_sample(in_file):
-    """Retrieve normal sample if normal/turmor
+    """Retrieve normal sample if normal/tumor
     """
     with utils.open_gzipsafe(in_file) as in_handle:
         for line in in_handle:

--- a/docs/contents/purecn.md
+++ b/docs/contents/purecn.md
@@ -89,7 +89,7 @@ $ bcbio_nextgen.py ../config/pon.yaml -n 20
 ```
 
 ### 4. Collect and save Normal DB and SNV PON
-Upon successfull bcbio run you may find resulting files in  `pon/final/[date]_pon`
+Upon successful bcbio run you may find resulting files in  `pon/final/[date]_pon`
 ```bash
 $ ls -1 pon/final/*_pon
 mapping_bias_hg38.rds
@@ -167,7 +167,7 @@ $ bcbio_nextgen.py ../config/ton.yaml -n 20
 ```
 
 ### 6. Collect PureCN results
-Upon successfull bcbio run PureCN results are saved in the folders of individual
+Upon successful bcbio run PureCN results are saved in the folders of individual
 samples
 ```
 $ ls -1 ton/final/sample1_T_FFPE/purecn


### PR DESCRIPTION
There are small typos in:
- bcbio/ngsalign/bwa.py
- bcbio/utils.py
- bcbio/variation/vcfutils.py
- docs/contents/purecn.md

Fixes:
- Should read `successful` rather than `successfull`.
- Should read `file` rather than `fils`.
- Should read `tumor` rather than `turmor`.
- Should read `occurrences` rather than `occurances`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md