### PR TITLE
Provide a bait file to Picard's CollectHsMetrics

### DIFF
--- a/bcbio/pipeline/datadict.py
+++ b/bcbio/pipeline/datadict.py
@@ -166,6 +166,7 @@ LOOKUPS = {
     "vrn_file": {"keys": ["vrn_file"]},
     "exclude_regions": {"keys": ["config", "algorithm", "exclude_regions"], "default": [],
                         "always_list": True},
+    "bait_regions": {"keys": ["config", "algorithm", "bait_regions"]},
     "variant_regions": {"keys": ["config", "algorithm", "variant_regions"]},
     "variant_regions_merged": {"keys": ["config", "algorithm", "variant_regions_merged"]},
     "variant_regions_orig": {"keys": ["config", "algorithm", "variant_regions_orig"]},

--- a/bcbio/qc/picard.py
+++ b/bcbio/qc/picard.py
@@ -14,6 +14,7 @@ def run(bam_file, data, out_dir):
     ref_file = dd.get_ref_file(data)
     sample = dd.get_sample_name(data)
     target_file = dd.get_variant_regions(data) or dd.get_sample_callable(data)
+    bait_file = dd.get_bait_regions(data) or target_file
     broad_runner = broad.PicardCmdRunner("picard", data["config"])
     bam_fname = os.path.abspath(bam_file)
     path = os.path.dirname(bam_fname)
@@ -30,7 +31,7 @@ def run(bam_file, data, out_dir):
                 gen_metrics = PicardMetrics(broad_runner, tmp_dir)
                 gen_metrics.report(cur_bam, ref_file,
                                 bam.is_paired(bam_fname),
-                                target_file, target_file, None, data["config"])
+                                bait_file, target_file, None, data["config"])
         if utils.file_exists(hsmetric_file):
             do.run("sed -i 's/%s.bam//g' %s" % (out_base.replace(sample, ""), hsmetric_file), "")
         if utils.file_exists(hsinsert_file):


### PR DESCRIPTION
Hi!

I'm interested in providing proper bait files to Picard's CollectHsMetrics tool. From the code that I examined, bcbio currently forces both the bait file and the target file to be the same (eg: the file provided to variant_regions). This PR proposes to fix the small missing link that would allow providing a proper bait file.

1. It creates a ``config:algorithm:bait_regions`` entry in the datadict, which allows for providing a path to the bait file in the yaml config.
2. It gets the reference to this bait file properly passed over to the ``reports`` method of the PicardMetrics instance.

If anything is missing, I will gladly adapt this contribution as needed (updating the documentation, adding other missing elements that I oversaw, etc.).

Thank you! 